### PR TITLE
Ensure isConnected delegates to NNTP client

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/input/NewsClientImpl.java
+++ b/src/main/java/uk/co/sleonard/unison/input/NewsClientImpl.java
@@ -169,8 +169,12 @@ public class NewsClientImpl implements NewsClient {
 
 	@Override
 	public boolean isConnected() {
-		// TODO Auto-generated method stub
-		return false;
+		try {
+			return (this.client != null) && this.client.isConnected();
+		}
+		catch (final NullPointerException e) {
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- implement NewsClientImpl#isConnected to reflect underlying NNTPClient connection state
- safely handle potential NullPointerException when client is uninitialized

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: Plugin org.sonatype.plugins:nexus-staging-maven-plugin:1.6.3)*

------
https://chatgpt.com/codex/tasks/task_e_689cacad0d408327aff3d7785f8671ad