### PR TITLE
Handle RFC1123 dates via ZonedDateTime

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/utils/StringUtils.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/StringUtils.java
@@ -312,22 +312,22 @@ public class StringUtils {
 				final ZonedDateTime zonedDateTime = ZonedDateTime.parse(dateText, formatter);
 				return Date.from(zonedDateTime.toInstant());
 			}
-			else if (dateText.substring(0, 1).matches("[a-zA-Z]")) {
-				dateText = dateText.substring(4, dateText.length()).trim();
-				// Sun, 18 Jan 2015 23:40:56 +0000
-				// TRIM TO
-				// 18 Jan 2015 23:40:56 +0000
-				final DateTimeFormatter formatter = DateTimeFormatter.RFC_1123_DATE_TIME;
-				final ZonedDateTime zonedDateTime = ZonedDateTime.parse(dateText, formatter);
-				return Date.from(zonedDateTime.toInstant());
-			}
-			else {
-				// 30 Jan 2015 23:37:13 GMT
-				final DateTimeFormatter formatter = DateTimeFormatter.RFC_1123_DATE_TIME;
-				final LocalDate localDate = LocalDate.parse(dateText, formatter);
-				return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
-			}
-		}
-	}
+                        else if (dateText.substring(0, 1).matches("[a-zA-Z]")) {
+                                dateText = dateText.substring(4, dateText.length()).trim();
+                                // Sun, 18 Jan 2015 23:40:56 +0000
+                                // TRIM TO
+                                // 18 Jan 2015 23:40:56 +0000
+                                final DateTimeFormatter formatter = DateTimeFormatter.RFC_1123_DATE_TIME;
+                                final ZonedDateTime zonedDateTime = ZonedDateTime.parse(dateText, formatter);
+                                return Date.from(zonedDateTime.toInstant());
+                        }
+                        else {
+                                // 30 Jan 2015 23:37:13 GMT
+                                final DateTimeFormatter formatter = DateTimeFormatter.RFC_1123_DATE_TIME;
+                                final ZonedDateTime zonedDateTime = ZonedDateTime.parse(dateText, formatter);
+                                return Date.from(zonedDateTime.toInstant());
+                        }
+                }
+        }
 
 }

--- a/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
+++ b/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
@@ -178,9 +178,31 @@ public class StringUtilsTest {
 	/**
 	 * Test stringToDate with String length 10 throw UNISoNException
 	 */
-	@Test(expected = UNISoNException.class)
-	public void testStringToDateExceptionLength10() throws UNISoNException {
-		StringUtils.stringToDate("xx/xx/xxxx");
-	}
+        @Test(expected = UNISoNException.class)
+        public void testStringToDateExceptionLength10() throws UNISoNException {
+                StringUtils.stringToDate("xx/xx/xxxx");
+        }
+
+        /**
+         * Ensure RFC 1123 date strings with a weekday prefix are parsed.
+         */
+        @Test
+        public void testStringToDateRfc1123WithWeekday() throws UNISoNException {
+                Date actual = StringUtils.stringToDate("Sun, 18 Jan 2015 23:40:56 +0000");
+                assertTrue(actual.toString().contains("18"));
+                assertTrue(actual.toString().contains("Jan"));
+                assertTrue(actual.toString().contains("2015"));
+        }
+
+        /**
+         * Ensure RFC 1123 date strings without a weekday prefix are parsed.
+         */
+        @Test
+        public void testStringToDateRfc1123WithoutWeekday() throws UNISoNException {
+                Date actual = StringUtils.stringToDate("18 Jan 2015 23:40:56 +0000");
+                assertTrue(actual.toString().contains("18"));
+                assertTrue(actual.toString().contains("Jan"));
+                assertTrue(actual.toString().contains("2015"));
+        }
 
 }


### PR DESCRIPTION
## Summary
- parse RFC 1123 timestamps without weekday using `ZonedDateTime` in `stringToDate`
- add tests for RFC 1123 date strings with and without weekday prefixes

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: Plugin org.sonatype.plugins:nexus-staging-maven-plugin:1.6.3 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689cacaf7a64832798aba21ecb758c46

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/186)
<!-- Reviewable:end -->
