### PR TITLE
Implement quit delegation in NewsClientImpl

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/input/NewsClientImpl.java
+++ b/src/main/java/uk/co/sleonard/unison/input/NewsClientImpl.java
@@ -213,11 +213,16 @@ public class NewsClientImpl implements NewsClient {
 		return groupSet;
 	}
 
-	@Override
-	public int quit() throws IOException {
-		// TODO Auto-generated method stub
-		return 0;
-	}
+        @Override
+        public int quit() throws IOException {
+                try {
+                        return this.client.quit();
+                }
+                catch (final IOException e) {
+                        NewsClientImpl.logger.error("Error quitting NNTP client", e);
+                        throw e;
+                }
+        }
 
 	/**
 	 * Reconnect.


### PR DESCRIPTION
## Summary
- Implement `quit` in `NewsClientImpl` to delegate to underlying `NNTPClient`
- Log and rethrow any `IOException` from the NNTP client

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: nexus-staging-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_689cacae4a208327976e4143b5272a50