### PR TITLE
Improve server list loading

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/utils/StringUtils.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/StringUtils.java
@@ -29,6 +29,11 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.log4j.Logger;
+
 import uk.co.sleonard.unison.UNISoNException;
 
 /**
@@ -43,7 +48,10 @@ import uk.co.sleonard.unison.UNISoNException;
  */
 public class StringUtils {
 
-	static final String[] DATE_SEPARATORS = { "/", "-", ".", "," };
+        /** Logger for this class. */
+        private static final Logger LOG = Logger.getLogger(StringUtils.class);
+
+        static final String[] DATE_SEPARATORS = { "/", "-", ".", "," };
 
 	/**
 	 * Compress.
@@ -186,26 +194,61 @@ public class StringUtils {
 	 * @author Elton <elton_12_nunes@hotmail.com>
 	 * @return Return the server list on Array
 	 */
-	public static String[] loadServerList() {
+        public static String[] loadServerList() {
 
-		final Properties prop = new Properties();
-		final String file = "servers.properties";
+                final String file = "servers.properties";
 
-		try (final InputStream resources = ClassLoader.getSystemResourceAsStream(file);) {
-			if (null == resources) {
-				throw new IOException("can't find " + file);
-			}
-			prop.load(resources);
-			final List<String> list = StringUtils.convertCommasToList(prop.getProperty("servers"));
+                try (final InputStream resources = ClassLoader.getSystemResourceAsStream(file);) {
+                        if (null == resources) {
+                                throw new IOException("can't find " + file);
+                        }
+                        return loadServerList(resources);
+                }
+                catch (final IOException io) {
+                        LOG.error("Unable to load server list", io);
+                        return new String[0];
+                }
+        }
 
-			return list.toArray(new String[list.size()]);
-		}
-		catch (final IOException io) {
-			io.printStackTrace();
-		}
+        /**
+         * Load server list from an input stream.
+         *
+         * @param resources
+         *            the input stream
+         * @return the server list on Array
+         * @throws IOException
+         *             if there is a problem reading from the stream
+         */
+        public static String[] loadServerList(final InputStream resources) throws IOException {
 
-		return new String[] { "empty" };
-	}
+                if (resources == null) {
+                        return new String[0];
+                }
+
+                final Properties prop = new Properties();
+                prop.load(resources);
+                final String servers = prop.getProperty("servers");
+                if (servers == null) {
+                        return new String[0];
+                }
+                final List<String> list = StringUtils.convertCommasToList(servers);
+                return list.toArray(new String[0]);
+        }
+
+        /**
+         * Load server list from a properties file path.
+         *
+         * @param path
+         *            path to the properties file
+         * @return the server list on Array
+         * @throws IOException
+         *             if there is a problem reading the file
+         */
+        public static String[] loadServerList(final Path path) throws IOException {
+                try (InputStream in = Files.newInputStream(path)) {
+                        return loadServerList(in);
+                }
+        }
 
 	/**
 	 * Convert the String with date to Date Object.

--- a/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
+++ b/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
@@ -5,7 +5,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 import java.util.Vector;
@@ -91,11 +95,47 @@ public class StringUtilsTest {
 	 * Test loadServerList
 	 */
 	@Test
-	public void testLoadServerList() {
-		String[] actual = StringUtils.loadServerList();
-		assertNotNull(actual);
-		assertTrue(actual.length > 0);
-	}
+        public void testLoadServerList() {
+                String[] actual = StringUtils.loadServerList();
+                assertNotNull(actual);
+                assertTrue(actual.length > 0);
+        }
+
+        /**
+         * Test loadServerList with an input stream.
+         *
+         * @throws IOException
+         *             if something goes wrong
+         */
+        @Test
+        public void testLoadServerListFromStream() throws IOException {
+                try (ByteArrayInputStream in = new ByteArrayInputStream(
+                                "servers=host1,host2".getBytes(StandardCharsets.UTF_8))) {
+                        String[] servers = StringUtils.loadServerList(in);
+                        assertEquals(2, servers.length);
+                        assertEquals("host1", servers[0]);
+                        assertEquals("host2", servers[1]);
+                }
+        }
+
+        /**
+         * Test loadServerList with a path.
+         *
+         * @throws IOException
+         *             if something goes wrong
+         */
+        @Test
+        public void testLoadServerListFromPath() throws IOException {
+                Path temp = Files.createTempFile("servers", ".properties");
+                Files.write(temp, "servers=a,b".getBytes(StandardCharsets.UTF_8));
+                try {
+                        String[] servers = StringUtils.loadServerList(temp);
+                        assertEquals(2, servers.length);
+                }
+                finally {
+                        Files.deleteIfExists(temp);
+                }
+        }
 
 	/**
 	 * Test stringToDate


### PR DESCRIPTION
## Summary
- use log4j for `loadServerList` errors and return empty array on failure
- add overloads allowing server list loading from InputStream or Path
- test new server list loading helpers

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: Plugin org.sonatype.plugins:nexus-staging-maven-plugin:1.6.3)*

------
https://chatgpt.com/codex/tasks/task_e_689cacb36a1c8327920e74255c3c415d