### PR TITLE
chore: remove unused version properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
 		<java.version>17</java.version>
 		<powermock.version>1.6.5</powermock.version>
 		<mockito.version>1.10.19</mockito.version>
-		<javax.mail.version>1.4</javax.mail.version>
 		<maven-assembly-plugin.version>2.2-beta-4
 		</maven-assembly-plugin.version>
 		<jacoco.version>0.8.12</jacoco.version>
@@ -25,7 +24,6 @@
 		<httpunit.version>1.7</httpunit.version>
 		<oro.version>2.0.8</oro.version>
 		<javax-activation.version>1.1.1</javax-activation.version>
-		<googlecode-json.version>1.1</googlecode-json.version>
 		<antlr.version>2.7.7</antlr.version>
 		<asm.version>1.5.3</asm.version>
 		<asm-attrs.version>1.5.3</asm-attrs.version>
@@ -35,7 +33,6 @@
 		<commons-lang.version>2.6</commons-lang.version>
 		<commons-logging.version>1.3.2</commons-logging.version>
 		<db-ojb.version>1.0.4-patch9</db-ojb.version>
-		<dom4f.version>1.5.2</dom4f.version>
 		<ehcache.version>3.10.8</ehcache.version>
 		<hibernate-core.version>5.1.17.Final</hibernate-core.version>
 		<hibernate-tools.version>3.6.2.Final</hibernate-tools.version>


### PR DESCRIPTION
## Summary
- remove unused `javax.mail.version`, `googlecode-json.version`, and `dom4f.version` properties from `pom.xml`

## Testing
- `mvn -q test` *(fails: Unresolveable build extension org.sonatype.plugins:nexus-staging-maven-plugin:1.6.3)*

------
https://chatgpt.com/codex/tasks/task_e_689cb3a908f0832780729aeaef34c267