### PR TITLE
Replace commons-lang with commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<cglib.version>2.2.2</cglib.version>
 		<colt.version>1.2.0</colt.version>
 		<commons-collections.version>3.2.2</commons-collections.version>
-		<commons-lang.version>2.6</commons-lang.version>
+               <commons-lang3.version>3.14.0</commons-lang3.version>
 		<commons-logging.version>1.3.2</commons-logging.version>
 		<db-ojb.version>1.0.4-patch9</db-ojb.version>
 		<dom4f.version>1.5.2</dom4f.version>
@@ -300,11 +300,11 @@
 			<version>${commons-collections.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>${commons-lang.version}</version>
-		</dependency>
+               <dependency>
+                       <groupId>org.apache.commons</groupId>
+                       <artifactId>commons-lang3</artifactId>
+                       <version>${commons-lang3.version}</version>
+               </dependency>
 
 		<dependency>
 			<groupId>commons-logging</groupId>

--- a/src/it/java/uk/co/sleonard/unison/UNISoNControllerIT.java
+++ b/src/it/java/uk/co/sleonard/unison/UNISoNControllerIT.java
@@ -36,7 +36,7 @@ public class UNISoNControllerIT {
 		final ListModel<NewsGroup> model = this.controller.getAvailableGroupsModel(groups);
 		final NewsGroup firstGroup = model.getElementAt(0);
 		Assert.assertNotNull(firstGroup);
-		Assert.assertTrue(org.apache.commons.lang.StringUtils.isNotEmpty(firstGroup.getFullName()));
+               Assert.assertTrue(org.apache.commons.lang3.StringUtils.isNotEmpty(firstGroup.getFullName()));
 
 	}
 

--- a/src/main/java/uk/co/sleonard/unison/NewsGroupFilter.java
+++ b/src/main/java/uk/co/sleonard/unison/NewsGroupFilter.java
@@ -11,7 +11,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.Vector;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Session;
 
 import uk.co.sleonard.unison.datahandling.HibernateHelper;


### PR DESCRIPTION
## Summary
- replace deprecated commons-lang dependency with org.apache.commons:commons-lang3
- update code and tests to import org.apache.commons.lang3.StringUtils

## Testing
- `mvn -q -e test` *(fails: Unresolveable build extension for org.sonatype.plugins:nexus-staging-maven-plugin:1.6.3)*

------
https://chatgpt.com/codex/tasks/task_e_689cb3a7bcf08327a9c7ffce68165af0