### PR TITLE
Migrate to commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
      <slf4j.version>2.0.9</slf4j.version>
+     <slf4j-log4j12.version>2.0.9</slf4j-log4j12.version>
+     <log4j.version>1.2.17</log4j.version>
      <logback.version>1.4.14</logback.version>
 		<junit.version>4.13.2</junit.version>
 		<java.version>17</java.version>
@@ -31,7 +33,7 @@
 		<cglib.version>2.2.2</cglib.version>
 		<colt.version>1.2.0</colt.version>
 		<commons-collections.version>3.2.2</commons-collections.version>
-		<commons-lang.version>2.6</commons-lang.version>
+                <commons-lang3.version>3.14.0</commons-lang3.version>
 		<commons-logging.version>1.3.2</commons-logging.version>
 		<db-ojb.version>1.0.4-patch9</db-ojb.version>
 		<ehcache.version>3.10.8</ehcache.version>
@@ -251,9 +253,9 @@
 
 
                 <dependency>
-                        <groupId>commons-lang</groupId>
-                        <artifactId>commons-lang</artifactId>
-                        <version>${commons-lang.version}</version>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                        <version>${commons-lang3.version}</version>
                 </dependency>
 
                 <dependency>
@@ -335,12 +337,13 @@
 			<version>${jacoco.version}</version>
 			<type>maven-plugin</type>
 		</dependency>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.10.1</version>
+                <dependency>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                        <version>2.10.1</version>
+                </dependency>
 
-  <dependency>
+                <dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<version>1.18.30</version>

--- a/src/it/java/uk/co/sleonard/unison/UNISoNControllerIT.java
+++ b/src/it/java/uk/co/sleonard/unison/UNISoNControllerIT.java
@@ -35,7 +35,7 @@ public class UNISoNControllerIT {
 		final ListModel<NewsGroup> model = this.controller.getAvailableGroupsModel(groups);
 		final NewsGroup firstGroup = model.getElementAt(0);
 		Assert.assertNotNull(firstGroup);
-		Assert.assertTrue(org.apache.commons.lang.StringUtils.isNotEmpty(firstGroup.getFullName()));
+                Assert.assertTrue(org.apache.commons.lang3.StringUtils.isNotEmpty(firstGroup.getFullName()));
 
 	}
 

--- a/src/main/java/uk/co/sleonard/unison/NewsGroupFilter.java
+++ b/src/main/java/uk/co/sleonard/unison/NewsGroupFilter.java
@@ -11,7 +11,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.Vector;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Session;
 
 import uk.co.sleonard.unison.datahandling.HibernateHelper;


### PR DESCRIPTION
## Summary
- replace deprecated `org.apache.commons.lang.StringUtils` usage with `org.apache.commons.lang3.StringUtils`
- swap in `commons-lang3` dependency and add missing logging version properties

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cb895daec8327a1b9fce18e6c189e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/197)
<!-- Reviewable:end -->
