### PR TITLE
docs: cite compression algorithm and fix pom dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,21 +32,23 @@
 		<colt.version>1.2.0</colt.version>
 		<commons-collections.version>3.2.2</commons-collections.version>
 		<commons-lang.version>2.6</commons-lang.version>
-		<commons-logging.version>1.3.2</commons-logging.version>
-		<db-ojb.version>1.0.4-patch9</db-ojb.version>
-		<ehcache.version>3.10.8</ehcache.version>
-		<hibernate-core.version>5.1.17.Final</hibernate-core.version>
-		<hibernate-tools.version>3.6.2.Final</hibernate-tools.version>
-		<hsqldb.version>1.8.0.10</hsqldb.version>
-		<jdom.version>b9</jdom.version>
-		<jta.version>1.1</jta.version>
-		<jtidy.version>r8-20060801</jtidy.version>
-		<jung.version>1.7.6</jung.version>
-		<oscache.version>2.4.1</oscache.version>
-		<swing-layout.version>1.0.3</swing-layout.version>
-		<mail.version>1.4.7</mail.version>
-		<dom4j.version>1.6.1</dom4j.version>
-	</properties>
+                <commons-logging.version>1.3.2</commons-logging.version>
+                <db-ojb.version>1.0.4-patch9</db-ojb.version>
+                <ehcache.version>3.10.8</ehcache.version>
+                <hibernate-core.version>5.1.17.Final</hibernate-core.version>
+                <hibernate-tools.version>3.6.2.Final</hibernate-tools.version>
+                <hsqldb.version>1.8.0.10</hsqldb.version>
+                <jdom.version>b9</jdom.version>
+                <jta.version>1.1</jta.version>
+                <jtidy.version>r8-20060801</jtidy.version>
+                <jung.version>1.7.6</jung.version>
+                <oscache.version>2.4.1</oscache.version>
+                <swing-layout.version>1.0.3</swing-layout.version>
+                <mail.version>1.4.7</mail.version>
+                <dom4j.version>1.6.1</dom4j.version>
+                <slf4j-log4j12.version>1.7.36</slf4j-log4j12.version>
+                <log4j.version>1.2.17</log4j.version>
+        </properties>
 
 	<build>
 		<plugins>
@@ -335,17 +337,18 @@
 			<version>${jacoco.version}</version>
 			<type>maven-plugin</type>
 		</dependency>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.10.1</version>
+                <dependency>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                        <version>2.10.1</version>
+                </dependency>
 
-  <dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.30</version>
-			<scope>compile</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>1.18.30</version>
+                        <scope>compile</scope>
+                </dependency>
 	</dependencies>
     
 	<reporting>

--- a/src/main/java/uk/co/sleonard/unison/utils/StringUtils.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/StringUtils.java
@@ -40,7 +40,7 @@ import uk.co.sleonard.unison.UNISoNException;
 /**
  * The Class StringUtils. </br>
  * </br>
- * TODO Add this reference for the compression FRom
+ * Compression algorithm adapted from a discussion on the Sun Java forums:
  * http://forum.java.sun.com/thread.jspa?threadID=250124&messageID=926638
  *
  * @author Stephen <github@leonarduk.com>


### PR DESCRIPTION
## Summary
- cite the source of compression/decompression algorithm in StringUtils
- correct pom.xml by closing a dependency block and defining missing versions

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cbb4114d883279a464199d41ed784