### PR TITLE
Use commons-lang3 instead of legacy commons-lang

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<cglib.version>2.2.2</cglib.version>
 		<colt.version>1.2.0</colt.version>
 		<commons-collections.version>3.2.2</commons-collections.version>
-		<commons-lang.version>2.6</commons-lang.version>
+                <commons-lang3.version>3.14.0</commons-lang3.version>
 		<commons-logging.version>1.3.2</commons-logging.version>
 		<db-ojb.version>1.0.4-patch9</db-ojb.version>
 		<ehcache.version>3.10.8</ehcache.version>
@@ -251,9 +251,9 @@
 
 
                 <dependency>
-                        <groupId>commons-lang</groupId>
-                        <artifactId>commons-lang</artifactId>
-                        <version>${commons-lang.version}</version>
+                        <groupId>org.apache.commons</groupId>
+                        <artifactId>commons-lang3</artifactId>
+                        <version>${commons-lang3.version}</version>
                 </dependency>
 
                 <dependency>
@@ -335,17 +335,18 @@
 			<version>${jacoco.version}</version>
 			<type>maven-plugin</type>
 		</dependency>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.10.1</version>
+                <dependency>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                        <version>2.10.1</version>
+                </dependency>
 
-  <dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.30</version>
-			<scope>compile</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>1.18.30</version>
+                        <scope>compile</scope>
+                </dependency>
 	</dependencies>
     
 	<reporting>


### PR DESCRIPTION
## Summary
- replace deprecated `commons-lang` dependency with `org.apache.commons:commons-lang3` 3.14.0
- rename property to `commons-lang3.version` and reference it in the new dependency
- fix gson dependency closure to keep `pom.xml` well-formed

## Testing
- `mvn -q test` *(fails: 'dependencies.dependency.version' for org.slf4j:slf4j-log4j12:jar must be a valid version but is '${slf4j-log4j12.version}')*

------
https://chatgpt.com/codex/tasks/task_e_689cb894be588327b5b78d8b67a818ea

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/199)
<!-- Reviewable:end -->
