### PR TITLE
Fix POM dependency closure and version properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
      <slf4j.version>2.0.9</slf4j.version>
+     <slf4j-log4j12.version>2.0.9</slf4j-log4j12.version>
+     <log4j.version>1.2.17</log4j.version>
      <logback.version>1.4.14</logback.version>
 		<junit.version>4.13.2</junit.version>
 		<java.version>17</java.version>
@@ -335,17 +337,18 @@
 			<version>${jacoco.version}</version>
 			<type>maven-plugin</type>
 		</dependency>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.10.1</version>
+                <dependency>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                        <version>2.10.1</version>
+                </dependency>
 
-  <dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.30</version>
-			<scope>compile</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>1.18.30</version>
+                        <scope>compile</scope>
+                </dependency>
 	</dependencies>
     
 	<reporting>


### PR DESCRIPTION
## Summary
- add missing slf4j-log4j12 and log4j version properties
- close gson dependency block to make pom parseable

## Testing
- `mvn -e -q clean install` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cb896ca50832797a75716c11f7a32