### PR TITLE
Log CSV export errors and alert users

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/gui/generated/PajekPanel.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/PajekPanel.java
@@ -23,6 +23,8 @@ import javax.swing.JFrame;
 import javax.swing.table.DefaultTableModel;
 
 import org.hibernate.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import uk.co.sleonard.unison.UNISoNController;
 import uk.co.sleonard.unison.UNISoNException;
@@ -46,14 +48,17 @@ import uk.co.sleonard.unison.utils.StringUtils;
  */
 class PajekPanel extends javax.swing.JPanel implements Observer {
 
-	/** The Constant PAJEK_NETWORK_FILE_SUFFIX. */
-	private static final String PAJEK_NETWORK_FILE_SUFFIX = ".net";
+        /** The Constant PAJEK_NETWORK_FILE_SUFFIX. */
+        private static final String PAJEK_NETWORK_FILE_SUFFIX = ".net";
 
-	/** The Constant serialVersionUID. */
-	private static final long serialVersionUID = 84102596787648747L;
+        /** The Constant serialVersionUID. */
+        private static final long serialVersionUID = 84102596787648747L;
 
-	/** The pajek file. */
-	private PajekNetworkFile pajekFile;
+        /** Logger for this class. */
+        private static final Logger LOG = LoggerFactory.getLogger(PajekPanel.class);
+
+        /** The pajek file. */
+        private PajekNetworkFile pajekFile;
 
 	/** The frame. */
 	private JFrame frame;
@@ -205,16 +210,15 @@ class PajekPanel extends javax.swing.JPanel implements Observer {
 	 * @param evt
 	 *            the evt
 	 */
-	private void csvButtonActionPerformed(final java.awt.event.ActionEvent evt) {// GEN-FIRST:event_csvButtonActionPerformed
-		try {
-			this.csvExporter.exportTableToCSV(this.resultsMatrixTable, this.pajekHeader);
-		}
-		catch (final UNISoNException e) {
-			// TODO Auto-generated catch block
-
-			e.printStackTrace();
-		}
-	}// GEN-LAST:event_csvButtonActionPerformed
+        private void csvButtonActionPerformed(final java.awt.event.ActionEvent evt) {// GEN-FIRST:event_csvButtonActionPerformed
+                try {
+                        this.csvExporter.exportTableToCSV(this.resultsMatrixTable, this.pajekHeader);
+                }
+                catch (final UNISoNException e) {
+                        LOG.error("Error exporting CSV", e);
+                        this.controller.getGui().showAlert("Error: " + e.getMessage());
+                }
+        }// GEN-LAST:event_csvButtonActionPerformed
 
 	public javax.swing.JTextArea getFilePreviewArea() {
 		return this.filePreviewArea;

--- a/src/test/java/uk/co/sleonard/unison/gui/generated/PajekPanelTest.java
+++ b/src/test/java/uk/co/sleonard/unison/gui/generated/PajekPanelTest.java
@@ -1,0 +1,72 @@
+package uk.co.sleonard.unison.gui.generated;
+
+import static org.junit.Assert.assertTrue;
+
+import java.awt.event.ActionEvent;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Vector;
+
+import javax.swing.JTable;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.slf4j.LoggerFactory;
+
+import uk.co.sleonard.unison.UNISoNController;
+import uk.co.sleonard.unison.UNISoNException;
+import uk.co.sleonard.unison.gui.UNISoNGUI;
+import uk.co.sleonard.unison.output.ExportToCSV;
+
+/**
+ * Tests for {@link PajekPanel}.
+ */
+public class PajekPanelTest {
+
+    @Test
+    public void csvButtonLogsAndAlertsOnException() throws Exception {
+        PajekPanel panel = Mockito.mock(PajekPanel.class,
+                Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+
+        ExportToCSV csvMock = Mockito.mock(ExportToCSV.class);
+        UNISoNException ex = new UNISoNException("boom");
+        Mockito.doThrow(ex).when(csvMock).exportTableToCSV(Mockito.any(JTable.class), Mockito.any());
+
+        UNISoNController controllerMock = Mockito.mock(UNISoNController.class);
+        UNISoNGUI guiMock = Mockito.mock(UNISoNGUI.class);
+        Mockito.when(controllerMock.getGui()).thenReturn(guiMock);
+
+        setField(panel, "csvExporter", csvMock);
+        setField(panel, "resultsMatrixTable", new JTable());
+        setField(panel, "pajekHeader", new Vector<String>());
+        setField(panel, "controller", controllerMock);
+
+        Logger logger = (Logger) LoggerFactory.getLogger(PajekPanel.class);
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+
+        Method m = PajekPanel.class.getDeclaredMethod("csvButtonActionPerformed",
+                java.awt.event.ActionEvent.class);
+        m.setAccessible(true);
+        m.invoke(panel, new ActionEvent(panel, ActionEvent.ACTION_PERFORMED, "csv"));
+
+        Mockito.verify(guiMock).showAlert("Error: " + ex.getMessage());
+        assertTrue(listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.ERROR
+                        && event.getMessage().contains("Error exporting CSV")));
+    }
+
+    private static void setField(final Object target, final String name, final Object value)
+            throws Exception {
+        Field field = PajekPanel.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace `printStackTrace` in `PajekPanel` with SLF4J logger and GUI alert
- add unit test ensuring CSV export errors log and alert

## Testing
- `mvn -q test` *(fails: Non-parseable POM /workspace/unison/pom.xml: Unrecognised tag: 'dependency')*

------
https://chatgpt.com/codex/tasks/task_e_689cbb45584c8327b0f534f884dffe30

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/201)
<!-- Reviewable:end -->
