### PR TITLE
Remove dead Get Text and progress UI

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/gui/generated/DownloadNewsPanel.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/DownloadNewsPanel.java
@@ -42,12 +42,6 @@ class DownloadNewsPanel extends javax.swing.JPanel
 	/** The download button. */
 	private javax.swing.JButton downloadButton;
 
-	/** The download progress bar. */
-	private javax.swing.JProgressBar downloadProgressBar;
-
-	/** The download progress label. */
-	private javax.swing.JLabel downloadProgressLabel;
-
 	/** The find button. */
 	private javax.swing.JButton findButton;
 
@@ -60,8 +54,6 @@ class DownloadNewsPanel extends javax.swing.JPanel
 	/** The get location check. */
 	private javax.swing.JCheckBox getLocationCheck;
 
-	/** The get text check. */
-	private javax.swing.JCheckBox getTextCheck;
 
 	/** The host combo. */
 	private javax.swing.JComboBox hostCombo;
@@ -152,12 +144,7 @@ class DownloadNewsPanel extends javax.swing.JPanel
 		DataHibernatorWorker.setLogger(this);
 		this.controller.setDownloadPanel(this);
 
-		// FIXME - disable these until they work
-		this.getTextCheck.setVisible(false);
-		this.downloadProgressBar.setVisible(false);
-		this.downloadProgressLabel.setVisible(false);
-
-	}
+        }
 
 	/*
 	 * (non-Javadoc)
@@ -198,9 +185,10 @@ class DownloadNewsPanel extends javax.swing.JPanel
 	 */
 	@SuppressWarnings("deprecation")
 	private void downloadButtonActionPerformed(final java.awt.event.ActionEvent evt) {// GEN-FIRST:event_downloadButtonActionPerformed
-		this.controller.download(this, (NewsGroup[]) this.availableNewsgroups.getSelectedValues(),
-		        this.fromDateField.getText(), this.toDateField.getText(), this,
-		        this.getLocationCheck.isSelected(), this.getTextCheck.isSelected());
+                this.controller.download(this,
+                        (NewsGroup[]) this.availableNewsgroups.getSelectedValues(),
+                        this.fromDateField.getText(), this.toDateField.getText(), this,
+                        this.getLocationCheck.isSelected(), false);
 	}// GEN-LAST:event_downloadButtonActionPerformed
 
 	/**
@@ -216,7 +204,6 @@ class DownloadNewsPanel extends javax.swing.JPanel
 		this.toDateLabel.setEnabled(enabled);
 		this.fromDateField.setEnabled(enabled);
 		this.toDateField.setEnabled(enabled);
-		this.getTextCheck.setEnabled(enabled);
 		this.getLocationCheck.setEnabled(enabled);
 
 		// these are off when download on & vice versa
@@ -257,12 +244,10 @@ class DownloadNewsPanel extends javax.swing.JPanel
 	@SuppressWarnings("unchecked")
 	private void initComponents() {
 		this.newsgroupLabel = new javax.swing.JLabel();
-		this.newsgroupField = new javax.swing.JTextField();
-		this.downloadProgressBar = new javax.swing.JProgressBar();
-		this.downloadProgressLabel = new javax.swing.JLabel();
-		this.findButton = new javax.swing.JButton();
-		this.fromDateLabel = new javax.swing.JLabel();
-		this.toDateLabel = new javax.swing.JLabel();
+                this.newsgroupField = new javax.swing.JTextField();
+                this.findButton = new javax.swing.JButton();
+                this.fromDateLabel = new javax.swing.JLabel();
+                this.toDateLabel = new javax.swing.JLabel();
 		this.toDateField = new javax.swing.JTextField();
 		this.fromDateField = new javax.swing.JTextField();
 		this.downloadButton = new javax.swing.JButton();
@@ -270,13 +255,12 @@ class DownloadNewsPanel extends javax.swing.JPanel
 		this.cancelButton = new javax.swing.JButton();
 		this.jScrollPane3 = new javax.swing.JScrollPane();
 		this.notesArea = new javax.swing.JTextArea();
-		this.logText = new StringBuffer();
-		this.hostLabel = new javax.swing.JLabel();
-		this.getTextCheck = new javax.swing.JCheckBox();
-		this.getLocationCheck = new javax.swing.JCheckBox();
-		this.hostCombo = new javax.swing.JComboBox();
-		this.jScrollPane1 = new javax.swing.JScrollPane();
-		this.availableNewsgroups = new javax.swing.JList<>();
+                this.logText = new StringBuffer();
+                this.hostLabel = new javax.swing.JLabel();
+                this.getLocationCheck = new javax.swing.JCheckBox();
+                this.hostCombo = new javax.swing.JComboBox();
+                this.jScrollPane1 = new javax.swing.JScrollPane();
+                this.availableNewsgroups = new javax.swing.JList<>();
 
 		this.addMouseListener(new java.awt.event.MouseAdapter() {
 			@Override
@@ -292,10 +276,8 @@ class DownloadNewsPanel extends javax.swing.JPanel
 		this.newsgroupField.setToolTipText(
 		        "Type in full or part name (use * for wild character, e.g. *senior* for all groups with \"senior\" in the name)");
 
-		this.downloadProgressLabel.setText("Download Status");
-
-		this.findButton.setText("Find groups");
-		this.findButton
+                this.findButton.setText("Find groups");
+                this.findButton
 		        .setToolTipText("Enter name or part name (* for wild chararcter) the n click here");
 		this.findButton
 		        .addActionListener(evt -> DownloadNewsPanel.this.findButtonActionPerformed(evt));
@@ -330,13 +312,9 @@ class DownloadNewsPanel extends javax.swing.JPanel
 		this.hostLabel.setToolTipText(
 		        "Look at http://freeusenetnews.com/newspage.html?sortby=articles for other hosts if these are broken. Can enter name here.");
 
-		this.getTextCheck.setText("Get Text");
-		this.getTextCheck.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
-		this.getTextCheck.setMargin(new java.awt.Insets(0, 0, 0, 0));
-
-		this.getLocationCheck.setText("Get Location");
-		this.getLocationCheck.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
-		this.getLocationCheck.setMargin(new java.awt.Insets(0, 0, 0, 0));
+                this.getLocationCheck.setText("Get Location");
+                this.getLocationCheck.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
+                this.getLocationCheck.setMargin(new java.awt.Insets(0, 0, 0, 0));
 
 		this.hostCombo.setEditable(true);
 		this.hostCombo.setModel(new javax.swing.DefaultComboBoxModel(StringUtils.loadServerList()));
@@ -351,158 +329,133 @@ class DownloadNewsPanel extends javax.swing.JPanel
 
 		this.jScrollPane1.setViewportView(this.availableNewsgroups);
 
-		final javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
-		this.setLayout(layout);
-		layout.setHorizontalGroup(layout
-		        .createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-		        .addGroup(layout.createSequentialGroup().addContainerGap().addGroup(layout
-		                .createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-		                .addComponent(this.jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 262,
-		                        Short.MAX_VALUE)
-		                .addComponent(this.downloadProgressLabel)
-		                .addGroup(layout.createSequentialGroup().addComponent(this.newsgroupLabel)
-		                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                        .addComponent(this.newsgroupField,
-		                                javax.swing.GroupLayout.DEFAULT_SIZE, 175, Short.MAX_VALUE))
-		                .addGroup(layout.createSequentialGroup().addComponent(this.hostLabel)
-		                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED,
-		                                17, Short.MAX_VALUE)
-		                        .addComponent(this.hostCombo,
-		                                javax.swing.GroupLayout.PREFERRED_SIZE,
-		                                javax.swing.GroupLayout.DEFAULT_SIZE,
-		                                javax.swing.GroupLayout.PREFERRED_SIZE))
-		                .addComponent(this.downloadProgressBar,
-		                        javax.swing.GroupLayout.DEFAULT_SIZE, 262, Short.MAX_VALUE))
-		                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                .addGroup(layout
-		                        .createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-		                        .addGroup(layout
-		                                .createParallelGroup(
-		                                        javax.swing.GroupLayout.Alignment.TRAILING)
-		                                .addGroup(layout
-		                                        .createParallelGroup(
-		                                                javax.swing.GroupLayout.Alignment.LEADING)
-		                                        .addComponent(this.downloadButton)
-		                                        .addComponent(this.fromDateLabel)
-		                                        .addComponent(this.fromDateField,
-		                                                javax.swing.GroupLayout.PREFERRED_SIZE,
-		                                                javax.swing.GroupLayout.DEFAULT_SIZE,
-		                                                javax.swing.GroupLayout.PREFERRED_SIZE)
-		                                        .addComponent(this.toDateField,
-		                                                javax.swing.GroupLayout.PREFERRED_SIZE,
-		                                                javax.swing.GroupLayout.DEFAULT_SIZE,
-		                                                javax.swing.GroupLayout.PREFERRED_SIZE)
-		                                        .addComponent(this.toDateLabel)
-		                                        .addComponent(this.cancelButton)
-		                                        .addComponent(this.pauseButton))
-		                                .addComponent(this.findButton))
-		                        .addComponent(this.getTextCheck)
-		                        .addComponent(this.getLocationCheck))
-		                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                .addComponent(this.jScrollPane3, javax.swing.GroupLayout.PREFERRED_SIZE,
-		                        193, javax.swing.GroupLayout.PREFERRED_SIZE)
-		                .addContainerGap()));
+                final javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
+                this.setLayout(layout);
+                layout.setHorizontalGroup(
+                        layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                .addGroup(layout.createSequentialGroup()
+                                        .addContainerGap()
+                                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                                .addComponent(this.jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 262,
+                                                        Short.MAX_VALUE)
+                                                .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(this.newsgroupLabel)
+                                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                        .addComponent(this.newsgroupField,
+                                                                javax.swing.GroupLayout.DEFAULT_SIZE, 175, Short.MAX_VALUE))
+                                                .addGroup(layout.createSequentialGroup()
+                                                        .addComponent(this.hostLabel)
+                                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED,
+                                                                17, Short.MAX_VALUE)
+                                                        .addComponent(this.hostCombo,
+                                                                javax.swing.GroupLayout.PREFERRED_SIZE,
+                                                                javax.swing.GroupLayout.DEFAULT_SIZE,
+                                                                javax.swing.GroupLayout.PREFERRED_SIZE)))
+                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                                .addGroup(layout.createParallelGroup(
+                                                        javax.swing.GroupLayout.Alignment.TRAILING)
+                                                        .addGroup(layout.createParallelGroup(
+                                                                javax.swing.GroupLayout.Alignment.LEADING)
+                                                                .addComponent(this.downloadButton)
+                                                                .addComponent(this.fromDateLabel)
+                                                                .addComponent(this.fromDateField,
+                                                                        javax.swing.GroupLayout.PREFERRED_SIZE,
+                                                                        javax.swing.GroupLayout.DEFAULT_SIZE,
+                                                                        javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                                .addComponent(this.toDateField,
+                                                                        javax.swing.GroupLayout.PREFERRED_SIZE,
+                                                                        javax.swing.GroupLayout.DEFAULT_SIZE,
+                                                                        javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                                .addComponent(this.toDateLabel)
+                                                                .addComponent(this.cancelButton)
+                                                                .addComponent(this.pauseButton))
+                                                        .addComponent(this.findButton))
+                                                .addComponent(this.getLocationCheck))
+                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                        .addComponent(this.jScrollPane3, javax.swing.GroupLayout.PREFERRED_SIZE, 193,
+                                                javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addContainerGap()));
 
-		layout.linkSize(javax.swing.SwingConstants.HORIZONTAL,
-		        new java.awt.Component[] { this.cancelButton, this.downloadButton, this.findButton,
-		                this.fromDateField, this.pauseButton, this.toDateField });
+                layout.linkSize(javax.swing.SwingConstants.HORIZONTAL,
+                        new java.awt.Component[] { this.cancelButton, this.downloadButton, this.findButton,
+                                this.fromDateField, this.pauseButton, this.toDateField });
 
-		layout.setVerticalGroup(
-		        layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING).addGroup(
-		                javax.swing.GroupLayout.Alignment.TRAILING,
-		                layout.createSequentialGroup().addGroup(layout
-		                        .createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-		                        .addGroup(layout.createSequentialGroup().addContainerGap()
-		                                .addGroup(layout.createParallelGroup(
-		                                        javax.swing.GroupLayout.Alignment.LEADING)
-		                                        .addGroup(layout.createSequentialGroup()
-		                                                .addGap(55, 55, 55)
-		                                                .addComponent(this.getTextCheck)
-		                                                .addPreferredGap(
-		                                                        javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                                                .addComponent(this.getLocationCheck)
-		                                                .addPreferredGap(
-		                                                        javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                                                .addComponent(this.fromDateLabel,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE,
-		                                                        14,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE)
-		                                                .addPreferredGap(
-		                                                        javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                                                .addComponent(this.fromDateField,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE,
-		                                                        20,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE)
-		                                                .addPreferredGap(
-		                                                        javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                                                .addComponent(this.toDateLabel,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE,
-		                                                        14,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE)
-		                                                .addPreferredGap(
-		                                                        javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                                                .addComponent(this.toDateField,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE,
-		                                                        20,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE)
-		                                                .addPreferredGap(
-		                                                        javax.swing.LayoutStyle.ComponentPlacement.RELATED,
-		                                                        59, Short.MAX_VALUE)
-		                                                .addComponent(this.downloadButton,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE,
-		                                                        23,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE)
-		                                                .addPreferredGap(
-		                                                        javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                                                .addComponent(this.pauseButton,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE,
-		                                                        23,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE)
-		                                                .addPreferredGap(
-		                                                        javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                                                .addComponent(this.cancelButton))
-		                                        .addComponent(this.findButton)))
-		                        .addGroup(layout.createSequentialGroup().addContainerGap()
-		                                .addComponent(this.jScrollPane3,
-		                                        javax.swing.GroupLayout.DEFAULT_SIZE, 325,
-		                                        Short.MAX_VALUE))
-		                        .addGroup(layout.createSequentialGroup().addGroup(layout
-		                                .createParallelGroup(
-		                                        javax.swing.GroupLayout.Alignment.LEADING)
-		                                .addGroup(layout.createSequentialGroup().addGap(46, 46, 46)
-		                                        .addGroup(layout
-		                                                .createParallelGroup(
-		                                                        javax.swing.GroupLayout.Alignment.BASELINE)
-		                                                .addComponent(this.hostLabel)
-		                                                .addComponent(this.hostCombo,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE,
-		                                                        javax.swing.GroupLayout.DEFAULT_SIZE,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE)))
-		                                .addGroup(layout.createSequentialGroup().addContainerGap()
-		                                        .addGroup(layout
-		                                                .createParallelGroup(
-		                                                        javax.swing.GroupLayout.Alignment.BASELINE)
-		                                                .addComponent(this.newsgroupLabel)
-		                                                .addComponent(this.newsgroupField,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE,
-		                                                        javax.swing.GroupLayout.DEFAULT_SIZE,
-		                                                        javax.swing.GroupLayout.PREFERRED_SIZE))))
-		                                .addPreferredGap(
-		                                        javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                                .addComponent(this.jScrollPane1,
-		                                        javax.swing.GroupLayout.DEFAULT_SIZE, 220,
-		                                        Short.MAX_VALUE)
-		                                .addPreferredGap(
-		                                        javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                                .addComponent(this.downloadProgressLabel)
-		                                .addPreferredGap(
-		                                        javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-		                                .addComponent(this.downloadProgressBar,
-		                                        javax.swing.GroupLayout.PREFERRED_SIZE,
-		                                        javax.swing.GroupLayout.DEFAULT_SIZE,
-		                                        javax.swing.GroupLayout.PREFERRED_SIZE)))
-		                        .addContainerGap()));
-	}// </editor-fold>//GEN-END:initComponents
+                layout.setVerticalGroup(
+                        layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                                                .addGroup(layout.createSequentialGroup().addContainerGap()
+                                                        .addGroup(layout.createParallelGroup(
+                                                                javax.swing.GroupLayout.Alignment.LEADING)
+                                                                .addGroup(layout.createSequentialGroup()
+                                                                        .addGap(55, 55, 55)
+                                                                        .addComponent(this.getLocationCheck)
+                                                                        .addPreferredGap(
+                                                                                javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                                        .addComponent(this.fromDateLabel,
+                                                                                javax.swing.GroupLayout.PREFERRED_SIZE, 14,
+                                                                                javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                                        .addPreferredGap(
+                                                                                javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                                        .addComponent(this.fromDateField,
+                                                                                javax.swing.GroupLayout.PREFERRED_SIZE, 20,
+                                                                                javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                                        .addPreferredGap(
+                                                                                javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                                        .addComponent(this.toDateLabel,
+                                                                                javax.swing.GroupLayout.PREFERRED_SIZE, 14,
+                                                                                javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                                        .addPreferredGap(
+                                                                                javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                                        .addComponent(this.toDateField,
+                                                                                javax.swing.GroupLayout.PREFERRED_SIZE, 20,
+                                                                                javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                                        .addPreferredGap(
+                                                                                javax.swing.LayoutStyle.ComponentPlacement.RELATED,
+                                                                                59, Short.MAX_VALUE)
+                                                                        .addComponent(this.downloadButton,
+                                                                                javax.swing.GroupLayout.PREFERRED_SIZE, 23,
+                                                                                javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                                        .addPreferredGap(
+                                                                                javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                                        .addComponent(this.pauseButton,
+                                                                                javax.swing.GroupLayout.PREFERRED_SIZE, 23,
+                                                                                javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                                        .addPreferredGap(
+                                                                                javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                                        .addComponent(this.cancelButton))
+                                                                .addComponent(this.findButton)))
+                                                .addGroup(layout.createSequentialGroup().addContainerGap()
+                                                        .addComponent(this.jScrollPane3,
+                                                                javax.swing.GroupLayout.DEFAULT_SIZE, 325,
+                                                                Short.MAX_VALUE))
+                                                .addGroup(layout.createSequentialGroup()
+                                                        .addGroup(layout.createParallelGroup(
+                                                                javax.swing.GroupLayout.Alignment.LEADING)
+                                                                .addGroup(layout.createSequentialGroup().addGap(46, 46, 46)
+                                                                        .addGroup(layout.createParallelGroup(
+                                                                                javax.swing.GroupLayout.Alignment.BASELINE)
+                                                                                .addComponent(this.hostLabel)
+                                                                                .addComponent(this.hostCombo,
+                                                                                        javax.swing.GroupLayout.PREFERRED_SIZE,
+                                                                                        javax.swing.GroupLayout.DEFAULT_SIZE,
+                                                                                        javax.swing.GroupLayout.PREFERRED_SIZE)))
+                                                                .addGroup(layout.createSequentialGroup().addContainerGap()
+                                                                        .addGroup(layout.createParallelGroup(
+                                                                                javax.swing.GroupLayout.Alignment.BASELINE)
+                                                                                .addComponent(this.newsgroupLabel)
+                                                                                .addComponent(this.newsgroupField,
+                                                                                        javax.swing.GroupLayout.PREFERRED_SIZE,
+                                                                                        javax.swing.GroupLayout.DEFAULT_SIZE,
+                                                                                        javax.swing.GroupLayout.PREFERRED_SIZE))))
+                                                        .addPreferredGap(
+                                                                javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                        .addComponent(this.jScrollPane1,
+                                                                javax.swing.GroupLayout.DEFAULT_SIZE, 220,
+                                                                Short.MAX_VALUE)))
+                                        .addContainerGap()));
+        }// </editor-fold>//GEN-END:initComponents
 
 	/*
 	 * (non-Javadoc)


### PR DESCRIPTION
## Summary
- drop unused Get Text checkbox and download progress components from DownloadNewsPanel
- simplify download action to always skip text retrieval

## Testing
- ⚠️ `mvn -q test` *(fails: Non-parseable POM /workspace/unison/pom.xml)*

------
https://chatgpt.com/codex/tasks/task_e_689cbb464bf08327ab31c045ec96e866

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/202)
<!-- Reviewable:end -->
