### PR TITLE
Use commons-lang3 and drop old property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
                 <javassist.version>3.30.2-GA</javassist.version>
                 <commons-net>3.10.0</commons-net>
                 <freemarker.version>2.3.33</freemarker.version>
-                <commons-lang.version>2.6</commons-lang.version>
+                <commons-lang3.version>3.14.0</commons-lang3.version>
                 <hibernate-core.version>5.6.15.Final</hibernate-core.version>
                 <hibernate-tools.version>5.6.15.Final</hibernate-tools.version>
                 <hsqldb.version>2.7.2</hsqldb.version>


### PR DESCRIPTION
## Summary
- replace old `commons-lang` property with `commons-lang3` using version 3.14.0
- ensure only `commons-lang3` dependency remains

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cc3af850483279e6e72216f33538a