### PR TITLE
chore: remove swing-layout dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
                 <hsqldb.version>2.7.2</hsqldb.version>
                 <jung.version>1.7.6</jung.version>
                 <oscache.version>2.4.1</oscache.version>
-                <swing-layout.version>1.0.4</swing-layout.version>
                 <mail.version>1.6.2</mail.version>
 	</properties>
 
@@ -281,12 +280,6 @@
 			<groupId>opensymphony</groupId>
 			<artifactId>oscache</artifactId>
 			<version>${oscache.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.swinglabs</groupId>
-			<artifactId>swing-layout</artifactId>
-			<version>${swing-layout.version}</version>
 		</dependency>
 
 		<!-- gnumail lib not found. Then we checked that the package used is (javax.mail). 


### PR DESCRIPTION
## Summary
- drop unused org.swinglabs:swing-layout dependency and rely on built-in GroupLayout

## Testing
- `mvn -q -e test` *(fails: Plugin org.jacoco:jacoco-maven-plugin could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cd08e241883279a633a3fd6df37ca