### PR TITLE
Use parameter binding for Hibernate queries

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperRunQueryTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperRunQueryTest.java
@@ -1,0 +1,53 @@
+package uk.co.sleonard.unison.datahandling;
+
+import static org.junit.Assert.*;
+
+import java.util.Map;
+import java.util.Vector;
+
+import org.hibernate.Session;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.co.sleonard.unison.UNISoNException;
+import uk.co.sleonard.unison.datahandling.DAO.Message;
+
+public class HibernateHelperRunQueryTest {
+
+    private HibernateHelper helper;
+    private Session session;
+
+    @Before
+    public void setUp() throws UNISoNException {
+        this.helper = new HibernateHelper(null);
+        this.session = this.helper.getHibernateSession();
+    }
+
+    @After
+    public void tearDown() {
+        if (this.session != null) {
+            this.session.close();
+        }
+    }
+
+    @Test
+    public void testRunQueryBindsParameters() {
+        Vector<Message> results = this.helper.runQuery(
+                "from Message m where m.subject = :subject",
+                Map.of("subject", "Duke Nukem Hall of Shame (update)"),
+                this.session,
+                Message.class);
+        assertEquals(1, results.size());
+    }
+
+    @Test
+    public void testRunQueryPreventsSqlInjection() {
+        Vector<Message> results = this.helper.runQuery(
+                "from Message m where m.subject = :subject",
+                Map.of("subject", "Duke Nukem Hall of Shame (update)' OR '1'='1"),
+                this.session,
+                Message.class);
+        assertTrue(results.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `HibernateHelper.runQuery` to use typed Hibernate `Query` and parameter binding
- add overload allowing parameter maps and use native queries for SQL
- add tests ensuring `runQuery` binds parameters and blocks SQL injection attempts

## Testing
- `mvn -q -Dmail.version=1.4.7 -Djacoco.skip=true test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.12 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cdb8e92488327ada6f9e947cf8b62

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/212)
<!-- Reviewable:end -->
