### PR TITLE
Add download progress bar and controller integration

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/UNISoNController.java
+++ b/src/main/java/uk/co/sleonard/unison/UNISoNController.java
@@ -25,6 +25,7 @@ import uk.co.sleonard.unison.datahandling.UNISoNDatabase;
 import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest.DownloadMode;
 import uk.co.sleonard.unison.datahandling.DAO.NewsGroup;
 import uk.co.sleonard.unison.gui.UNISoNGUI;
+import uk.co.sleonard.unison.gui.generated.DownloadNewsPanel;
 import uk.co.sleonard.unison.input.DataHibernatorPool;
 import uk.co.sleonard.unison.input.DataHibernatorWorker;
 import uk.co.sleonard.unison.input.HeaderDownloadWorker;
@@ -369,9 +370,12 @@ public class UNISoNController {
 	 * @param progress
 	 *            the new downloading state
 	 */
-	public void setDownloadingState(final int progress) {
-		this.setButtonState(false, false, true, true);
-	}
+        public void setDownloadingState(final int progress) {
+                this.setButtonState(false, false, true, true);
+                if (this.downloadPanel instanceof DownloadNewsPanel) {
+                        ((DownloadNewsPanel) this.downloadPanel).setProgress(progress);
+                }
+        }
 
 	/**
 	 * Sets the download panel.

--- a/src/main/java/uk/co/sleonard/unison/gui/generated/DownloadNewsPanel.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/DownloadNewsPanel.java
@@ -79,6 +79,9 @@ class DownloadNewsPanel extends javax.swing.JPanel
 	/** The pause button. */
 	private javax.swing.JButton pauseButton;
 
+	/** The progress bar. */
+	private javax.swing.JProgressBar progressBar;
+
 	/** The to date field. */
 	private javax.swing.JTextField	toDateField;
 	/** The to date label. */
@@ -261,6 +264,8 @@ class DownloadNewsPanel extends javax.swing.JPanel
                 this.hostCombo = new javax.swing.JComboBox();
                 this.jScrollPane1 = new javax.swing.JScrollPane();
                 this.availableNewsgroups = new javax.swing.JList<>();
+		this.progressBar = new javax.swing.JProgressBar();
+		this.progressBar.setStringPainted(true);
 
 		this.addMouseListener(new java.awt.event.MouseAdapter() {
 			@Override
@@ -375,7 +380,8 @@ class DownloadNewsPanel extends javax.swing.JPanel
                                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                         .addComponent(this.jScrollPane3, javax.swing.GroupLayout.PREFERRED_SIZE, 193,
                                                 javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addContainerGap()));
+                                        .addContainerGap()))
+                                .addComponent(this.progressBar, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
 
                 layout.linkSize(javax.swing.SwingConstants.HORIZONTAL,
                         new java.awt.Component[] { this.cancelButton, this.downloadButton, this.findButton,
@@ -454,6 +460,8 @@ class DownloadNewsPanel extends javax.swing.JPanel
                                                         .addComponent(this.jScrollPane1,
                                                                 javax.swing.GroupLayout.DEFAULT_SIZE, 220,
                                                                 Short.MAX_VALUE)))
+                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                        .addComponent(this.progressBar, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                                         .addContainerGap()));
         }// </editor-fold>//GEN-END:initComponents
 
@@ -466,6 +474,16 @@ class DownloadNewsPanel extends javax.swing.JPanel
 	public void log(final String message) {
 		this.logText.append(message + "\n");
 		this.notesArea.setText(this.logText.toString());
+	}
+
+	/**
+	 * Updates the download progress bar.
+	 *
+	 * @param progress
+	 *            the new progress value
+	 */
+	public void setProgress(final int progress) {
+		this.progressBar.setValue(progress);
 	}
 
 	/**

--- a/src/test/java/uk/co/sleonard/unison/gui/generated/DownloadNewsPanelTest.java
+++ b/src/test/java/uk/co/sleonard/unison/gui/generated/DownloadNewsPanelTest.java
@@ -1,0 +1,39 @@
+package uk.co.sleonard.unison.gui.generated;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Field;
+
+import javax.swing.JProgressBar;
+import javax.swing.JFrame;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import uk.co.sleonard.unison.UNISoNController;
+import uk.co.sleonard.unison.input.DataHibernatorPool;
+import uk.co.sleonard.unison.input.HeaderDownloadWorker;
+
+/**
+ * Tests for {@link DownloadNewsPanel}.
+ */
+public class DownloadNewsPanelTest {
+
+    @Test
+    public void progressBarUpdatesViaController() throws Exception {
+        JFrame frame = Mockito.mock(JFrame.class);
+        DataHibernatorPool pool = Mockito.mock(DataHibernatorPool.class);
+        UNISoNController controller = UNISoNController.create(frame, pool);
+        HeaderDownloadWorker worker = Mockito.mock(HeaderDownloadWorker.class);
+        controller.setHeaderDownloader(worker);
+
+        DownloadNewsPanel panel = new DownloadNewsPanel(controller);
+
+        controller.setDownloadingState(42);
+
+        Field barField = DownloadNewsPanel.class.getDeclaredField("progressBar");
+        barField.setAccessible(true);
+        JProgressBar bar = (JProgressBar) barField.get(panel);
+        assertEquals(42, bar.getValue());
+    }
+}


### PR DESCRIPTION
## Summary
- Add JProgressBar to `DownloadNewsPanel` and expose method to update progress
- Forward download progress through `UNISoNController.setDownloadingState`
- Cover progress updates with a GUI test

## Testing
- `mvn -q -Dmail.version=1.4.7 -Dtest=DownloadNewsPanelTest test` *(fails: plugin org.jacoco:jacoco-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689cdcac40f48327b910c8d1f73ebdeb

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/213)
<!-- Reviewable:end -->
