### PR TITLE
Update domain references to leonarduk.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ UNISoN is a Java-based NNTP client that can analyse messages to save to a Pajek-
 [![Download unison](https://a.fsdn.com/con/app/sf-download-button)](https://sourceforge.net/projects/unison-sna/files/latest/download)
 
 
-Run via [Java web start](http://unison.sleonard.co.uk/downloads/jnlp/launch.jnlp) - this is self-signed so you need to allow it
+Run via [Java web start](http://unison.leonarduk.com/downloads/jnlp/launch.jnlp) - this is self-signed so you need to allow it
 
-Just Go To *Startmenu >>Java >>Configure Java >> Security >> Edit site list >> Add >> "http://unison.sleonard.co.uk/" >> OK 
+Just Go To *Startmenu >>Java >>Configure Java >> Security >> Edit site list >> Add >> "http://unison.leonarduk.com/" >> OK
 
 
 

--- a/deploy/unison.jnlp
+++ b/deploy/unison.jnlp
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jnlp spec="1.0+" codebase="http://unison.sleonard.co.uk/downloads/jnlp" href="">
+<jnlp spec="1.0+" codebase="http://unison.leonarduk.com/downloads/jnlp" href="">
     <information>
         <title>Unison - Usenet incorporates social networks
         </title>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>uk.co.sleonard</groupId>
+        <groupId>com.leonarduk</groupId>
 	<artifactId>unison</artifactId>
 	<version>1.3.0-SNAPSHOT</version>
 	<name>unison</name>

--- a/src/main/java/uk/co/sleonard/unison/gui/generated/AboutDialog.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/AboutDialog.java
@@ -110,11 +110,11 @@ class AboutDialog extends javax.swing.JDialog {
 
 		this.jLabel4.setText("Stephen Leonard  ");
 
-		this.jLabel6.setText("unison@sleonard.co.uk");
+                this.jLabel6.setText("unison@leonarduk.com");
 
 		this.jLabel8.setText("V1.0   January 2008");
 
-		this.jLabel9.setText("http://unison.sleonard.co.uk");
+                this.jLabel9.setText("http://unison.leonarduk.com");
 
 		final javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this.getContentPane());
 		this.getContentPane().setLayout(layout);

--- a/src/main/resources/unison.jnlp
+++ b/src/main/resources/unison.jnlp
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jnlp spec="1.0+" codebase="http://unison.sleonard.co.uk/downloads/jnlp" href="">
+<jnlp spec="1.0+" codebase="http://unison.leonarduk.com/downloads/jnlp" href="">
     <information>
         <title>Unison - Usenet incorporates social networks
         </title>


### PR DESCRIPTION
## Summary
- replace legacy `sleonard.co.uk` links with `leonarduk.com`
- update JNLP descriptors, README, and GUI About dialog
- adjust Maven groupId to `com.leonarduk`

## Testing
- `mvn -q test` *(fails: dependencies.dependency.version for javax.mail:mail:jar must be a valid version but is '${mail.version}')*

------
https://chatgpt.com/codex/tasks/task_e_689cdcb2157883279152906250f2ffde

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/216)
<!-- Reviewable:end -->
