### PR TITLE
Filter topics by selected newsgroup

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewerTest.java
@@ -1,0 +1,86 @@
+/**
+ * MessageStoreViewerTest
+ */
+package uk.co.sleonard.unison.gui.generated;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hibernate.Session;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import uk.co.sleonard.unison.UNISoNController;
+import uk.co.sleonard.unison.NewsGroupFilter;
+import uk.co.sleonard.unison.datahandling.HibernateHelper;
+import uk.co.sleonard.unison.datahandling.DAO.NewsGroup;
+import uk.co.sleonard.unison.datahandling.DAO.Topic;
+import uk.co.sleonard.unison.gui.UNISoNGUI;
+import uk.co.sleonard.unison.utils.TreeNode;
+
+/**
+ * Tests for {@link MessageStoreViewer}.
+ */
+public class MessageStoreViewerTest {
+
+    private UNISoNController controller;
+    private NewsGroupFilter filter;
+
+    @Before
+    public void setUp() throws Exception {
+        this.controller = Mockito.mock(UNISoNController.class);
+        this.filter = Mockito.mock(NewsGroupFilter.class);
+        final HibernateHelper helper = Mockito.mock(HibernateHelper.class);
+        final Session session = Mockito.mock(Session.class);
+        final UNISoNGUI gui = Mockito.mock(UNISoNGUI.class);
+
+        Mockito.when(this.controller.helper()).thenReturn(helper);
+        Mockito.when(helper.getHibernateSession()).thenReturn(session);
+        Mockito.when(this.controller.getFilter()).thenReturn(this.filter);
+        Mockito.when(this.controller.getGui()).thenReturn(gui);
+
+        final Field instance = UNISoNController.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, this.controller);
+    }
+
+    @Test
+    public void testRefreshTopicHierarchyFiltersBySelectedNewsgroup() throws Exception {
+        final NewsGroup selected = new NewsGroup();
+        selected.setFullName("group1");
+
+        final NewsGroup other = new NewsGroup();
+        other.setFullName("group2");
+
+        final Set<NewsGroup> selectedSet = new HashSet<>();
+        selectedSet.add(selected);
+        final Topic topic1 = new Topic("t1", selectedSet);
+
+        final Set<NewsGroup> otherSet = new HashSet<>();
+        otherSet.add(other);
+        final Topic topic2 = new Topic("t2", otherSet);
+
+        final Set<Topic> topics = new HashSet<>();
+        topics.add(topic1);
+        topics.add(topic2);
+        selected.setTopics(topics);
+
+        Mockito.when(this.filter.getSelectedNewsgroup()).thenReturn(selected);
+        Mockito.when(this.filter.getTopicsFilter()).thenReturn(topics);
+
+        final MessageStoreViewer viewer = new MessageStoreViewer();
+        viewer.notifySelectedNewsGroupObservers();
+
+        final Field rootField = MessageStoreViewer.class.getDeclaredField("topicRoot");
+        rootField.setAccessible(true);
+        final TreeNode root = (TreeNode) rootField.get(viewer);
+
+        assertEquals(1, root.getChildCount());
+        final TreeNode child = (TreeNode) root.getChildAt(0);
+        assertEquals(topic1, child.getUserObject());
+    }
+}


### PR DESCRIPTION
## Summary
- filter topic hierarchy to only show topics from the currently selected newsgroup
- refresh topics tree when selecting a newsgroup from the top groups list
- add unit test to verify topic filtering by newsgroup

## Testing
- `mvn -q -e -Dtest=MessageStoreViewerTest -Dmail.version=2.0.1 -Djacoco.skip=true test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cdb91e470832786053eeb2708dcc4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/217)
<!-- Reviewable:end -->
