### PR TITLE
Throw exception when name and email missing

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/datahandling/UsenetUserHelperTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/UsenetUserHelperTest.java
@@ -22,8 +22,8 @@ public class UsenetUserHelperTest {
 	/**
 	 * Test parse field from EmailAddress.
 	 */
-	@Test
-	public void testParseFromField() throws Exception {
+        @Test
+        public void testParseFromField() throws Exception {
 		EmailAddress expected = new EmailAddress("Elton", "elton_12_nunes@hotmail.com",
 		        "localhost");
 		EmailAddress expected2 = new EmailAddress("Elton", "elton_12_nunes@hotmail.com", "UNKNOWN");
@@ -42,7 +42,16 @@ public class UsenetUserHelperTest {
 		assertEquals(expected3, actualList.get(7));
 		assertEquals(expected4, actualList.get(8));
 
-	}
+        }
+
+        /**
+         * Ensures an {@link IllegalArgumentException} is thrown when neither name nor
+         * email can be determined.
+         */
+        @Test(expected = IllegalArgumentException.class)
+        public void testParseFromFieldThrowsWhenMissingNameAndEmail() {
+                UsenetUserHelper.parseFromField("", "localhost");
+        }
 
 	/**
 	 * Method used by testParseFromField.


### PR DESCRIPTION
## Summary
- enforce EmailAddress creation to require a non-empty name or email, throwing `IllegalArgumentException` when both are absent
- document new behaviour and adjust parsing logic to catch and log invalid user data
- add unit test ensuring the exception is raised for empty from fields

## Testing
- `mvn -q test` *(fails: 'dependencies.dependency.version' for javax.mail:mail:jar must be a valid version but is '${mail.version}')*


------
https://chatgpt.com/codex/tasks/task_e_689cdb8e79bc8327ae52a0b283921b6e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/218)
<!-- Reviewable:end -->
