### PR TITLE
Throw exception when name and email missing

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/datahandling/UsenetUserHelper.java
+++ b/src/main/java/uk/co/sleonard/unison/datahandling/UsenetUserHelper.java
@@ -21,54 +21,59 @@ import uk.co.sleonard.unison.input.NewsArticle;
 @Slf4j
 class UsenetUserHelper {
 
-	/**
-	 * Augment data and create user.
-	 *
-	 * @param name
-	 *            the name
-	 * @param email
-	 *            the email
-	 * @param gender
-	 *            the gender
-	 * @param ipAddress
-	 *            the ip address
-	 * @return the email address
-	 */
-	private static EmailAddress augmentDataAndCreateUser(final String nameInput,
-	        final String emailInput, final String gender, final String ipAddressInput) {
-		EmailAddress emailAddress = null;
-		String name = nameInput;
-		String email = emailInput;
-		String ipAddress = ipAddressInput;
-		if ((null == ipAddress) || ipAddress.equals("")) {
-			ipAddress = "UNKNOWN";
-		}
+        /**
+         * Augment data and create user.
+         *
+         * @param name
+         *            the name
+         * @param email
+         *            the email
+         * @param gender
+         *            the gender
+         * @param ipAddress
+         *            the ip address
+         * @return the email address
+         * @throws IllegalArgumentException
+         *             if both {@code name} and {@code email} are {@code null} or empty
+         */
+        private static EmailAddress augmentDataAndCreateUser(final String nameInput,
+                final String emailInput, final String gender, final String ipAddressInput) {
+                EmailAddress emailAddress = null;
+                String name = nameInput;
+                String email = emailInput;
+                String ipAddress = ipAddressInput;
+                if ((null == ipAddress) || ipAddress.equals("")) {
+                        ipAddress = "UNKNOWN";
+                }
 
-		// TODO throw exception here instead?
-		// can only create if have either name or email
-		if ((null != email) || (null != name)) {
-			// create name from email if missing
-			if ((null == name) || name.equals("")) {
-				// if just email address
-				final int atIndex = email.indexOf("@");
-				if (atIndex > -1) {
-					name = email.substring(0, atIndex).trim();
-				}
-				else {
-					name = email.trim();
-					email = null;
-				}
-			}
-			// create email from name and ipAddress if missing
-			if ((null == email) || email.equals("")) {
-				email = name + "@" + ipAddress;
-			}
+                if (((name == null) || name.isEmpty()) && ((email == null) || email.isEmpty())) {
+                        throw new IllegalArgumentException("Both name and email cannot be null or empty");
+                }
 
-			emailAddress = new EmailAddress(name, email, ipAddress);
-		}
-		return emailAddress;
+                // can only create if have either name or email
+                if ((null != email) || (null != name)) {
+                        // create name from email if missing
+                        if ((null == name) || name.equals("")) {
+                                // if just email address
+                                final int atIndex = email.indexOf("@");
+                                if (atIndex > -1) {
+                                        name = email.substring(0, atIndex).trim();
+                                }
+                                else {
+                                        name = email.trim();
+                                        email = null;
+                                }
+                        }
+                        // create email from name and ipAddress if missing
+                        if ((null == email) || email.equals("")) {
+                                email = name + "@" + ipAddress;
+                        }
 
-	}
+                        emailAddress = new EmailAddress(name, email, ipAddress);
+                }
+                return emailAddress;
+
+        }
 
 	/**
 	 * Creates the user by removing brackets.

--- a/src/test/java/uk/co/sleonard/unison/datahandling/UsenetUserHelperTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/UsenetUserHelperTest.java
@@ -23,7 +23,7 @@ public class UsenetUserHelperTest {
 	 * Test parse field from EmailAddress.
 	 */
 	@Test
-	public void testParseFromField() throws Exception {
+        public void testParseFromField() throws Exception {
 		EmailAddress expected = new EmailAddress("Elton", "elton_12_nunes@hotmail.com",
 		        "localhost");
 		EmailAddress expected2 = new EmailAddress("Elton", "elton_12_nunes@hotmail.com", "UNKNOWN");
@@ -42,7 +42,15 @@ public class UsenetUserHelperTest {
 		assertEquals(expected3, actualList.get(7));
 		assertEquals(expected4, actualList.get(8));
 
-	}
+        }
+
+        /**
+         * Ensure exception is thrown when neither name nor email is provided.
+         */
+        @Test(expected = IllegalArgumentException.class)
+        public void testParseFromFieldWithoutNameOrEmail() {
+                UsenetUserHelper.parseFromField("", "localhost");
+        }
 
 	/**
 	 * Method used by testParseFromField.


### PR DESCRIPTION
## Summary
- Validate user creation by throwing `IllegalArgumentException` when both name and email are blank
- Cover missing name/email scenario with new unit test

## Testing
- `mvn -q -Dmail.version=1.4.7 test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.12)*

------
https://chatgpt.com/codex/tasks/task_e_689cdea68cec8327b97135d6fb60f4f6

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/220)
<!-- Reviewable:end -->
