### PR TITLE
Ensure user location updated only once

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/datahandling/HibernateHelper.java
+++ b/src/main/java/uk/co/sleonard/unison/datahandling/HibernateHelper.java
@@ -223,7 +223,6 @@ public class HibernateHelper {
         final UsenetUser poster = this.findOrCreateUsenetUser(article, session, gender);
         if ((null == poster.getLocation()) || !poster.getLocation().equals(location)) {
             poster.setLocation(location);
-            poster.setLocation(location);
             session.saveOrUpdate(poster);
         }
         return poster;

--- a/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperSetLocationTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperSetLocationTest.java
@@ -1,0 +1,40 @@
+package uk.co.sleonard.unison.datahandling;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Date;
+
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import uk.co.sleonard.unison.datahandling.DAO.Location;
+import uk.co.sleonard.unison.datahandling.DAO.UsenetUser;
+import uk.co.sleonard.unison.input.NewsArticle;
+
+public class HibernateHelperSetLocationTest {
+
+    @Test
+    public void testSetLocationCalledOnceWhenLocationChanges() throws Exception {
+        HibernateHelper helper = new HibernateHelper(null);
+        Session session = Mockito.mock(Session.class);
+        Query query = Mockito.mock(Query.class);
+        Mockito.when(session.getNamedQuery(Mockito.anyString())).thenReturn(query);
+        Mockito.when(query.setParameter(Mockito.anyString(), Mockito.any())).thenReturn(query);
+        UsenetUser poster = Mockito.mock(UsenetUser.class);
+        Mockito.when(query.uniqueResult()).thenReturn(poster);
+
+        Location oldLocation = new Location("OldCity", "OldCountry", "OC", false, new ArrayList<>(), new ArrayList<>());
+        Location newLocation = new Location("NewCity", "NewCountry", "NC", false, new ArrayList<>(), new ArrayList<>());
+        Mockito.when(poster.getLocation()).thenReturn(oldLocation);
+
+        NewsArticle article = new NewsArticle("id", 1, new Date(), "name@example.com", "subject", "refs", "content", "group", null);
+
+        Method method = HibernateHelper.class.getDeclaredMethod("createUsenetUser", NewsArticle.class, Session.class, Location.class, String.class);
+        method.setAccessible(true);
+        method.invoke(helper, article, session, newLocation, null);
+
+        Mockito.verify(poster, Mockito.times(1)).setLocation(newLocation);
+    }
+}


### PR DESCRIPTION
## Summary
- prevent duplicate location updates when creating a Usenet user
- add unit test verifying setLocation invoked once when location changes

## Testing
- `mvn -q -Dmail.version=1.4 test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:pom:0.8.12 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce1265b488327a94115ab3a2941f6

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/222)
<!-- Reviewable:end -->
