### PR TITLE
handle missing from field when creating users

### DIFF
--- a/src/it/java/uk/co/sleonard/unison/datahandling/HibernateHelperIT.java
+++ b/src/it/java/uk/co/sleonard/unison/datahandling/HibernateHelperIT.java
@@ -33,7 +33,8 @@ public class HibernateHelperIT {
 		Assert.assertNotNull(article);
 		// Assert.assertNotNull(helper.findUsenetUser(article, session));
 //		Assert.assertTrue(helper.hibernateData(article, session));
-		final UsenetUser user = helper.findUsenetUser(article, session);
+                final UsenetUser user = helper
+                        .findUsenetUser(UsenetUserHelper.parseFromField(article), session);
 //		Assert.assertNotNull(user);
 //		final Message message = helper.createMessage(article, null, user);
 //		final Message findMessage = helper.findMessage(message, session);

--- a/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperFindOrCreateUsenetUserTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperFindOrCreateUsenetUserTest.java
@@ -1,0 +1,41 @@
+package uk.co.sleonard.unison.datahandling;
+
+import static org.junit.Assert.assertThrows;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Date;
+
+import org.hibernate.Session;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import uk.co.sleonard.unison.UNISoNException;
+import uk.co.sleonard.unison.input.NewsArticle;
+
+/**
+ * Tests for {@link HibernateHelper#findOrCreateUsenetUser(NewsArticle, Session, String)}.
+ */
+public class HibernateHelperFindOrCreateUsenetUserTest {
+
+    @Test
+    public void throwsExceptionWhenFromFieldInvalid() throws Exception {
+        HibernateHelper helper = new HibernateHelper(null);
+        Session session = Mockito.mock(Session.class);
+        NewsArticle article = new NewsArticle("id", 1, new Date(), "", "subj", "", null, "alt.test",
+                "127.0.0.1");
+
+        Method m = HibernateHelper.class.getDeclaredMethod("findOrCreateUsenetUser", NewsArticle.class,
+                Session.class, String.class);
+        m.setAccessible(true);
+
+        assertThrows(UNISoNException.class, () -> {
+            try {
+                m.invoke(helper, article, session, null);
+            }
+            catch (InvocationTargetException e) {
+                throw e.getCause();
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- validate parsed email address in `findOrCreateUsenetUser` and throw descriptive `UNISoNException` when missing
- allow `createUsenetUser` to propagate `UNISoNException`
- add regression test for empty `From` header

## Testing
- `mvn -q test` *(fails: 'dependencies.dependency.version' for javax.mail:mail:jar must be a valid version but is '${mail.version}')*
- `mvn -q -Dmail.version=1.4 test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.12 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ce124a1b08327a506ce4fabf685d5

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/224)
<!-- Reviewable:end -->
