### PR TITLE
Update Hibernate dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
                 <freemarker.version>2.3.33</freemarker.version>
                 <commons-lang3.version>3.14.0</commons-lang3.version>
 
-                <hibernate-core.version>5.6.18.Final</hibernate-core.version>
-                <hibernate-tools.version>5.6.18.Final</hibernate-tools.version>
+                <hibernate-core.version>5.6.20.Final</hibernate-core.version>
+                <hibernate-tools.version>5.6.20.Final</hibernate-tools.version>
                 <hsqldb.version>2.7.3</hsqldb.version>
                 <jung.version>1.7.6</jung.version>
                 <ehcache.version>3.10.8</ehcache.version>


### PR DESCRIPTION
## Summary
- bump Hibernate core and tools to version 5.6.20.Final for security

## Testing
- `mvn -U clean verify -Dmail.version=1.4.7` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.12, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cf3e18b208327919b427c9297c39b

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/225)
<!-- Reviewable:end -->
