### PR TITLE
Update failsafe plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 				<!-- run the integration tests -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.18.1</version>
+                                <version>3.1.2</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
## Summary
- bump maven-failsafe-plugin to 3.1.2

## Testing
- `mvn -q -e verify` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cf68bf4f88327abe6b4750682d8bd