### PR TITLE
Disable network-dependent integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
                 <ehcache.version>3.10.8</ehcache.version>
                 <swing-layout.version>1.0.4</swing-layout.version>
                 <jakarta.mail.version>2.1.3</jakarta.mail.version>
+                <skipITs>true</skipITs>
         </properties>
 
 	<build>
@@ -115,20 +116,23 @@
                                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                                 </configuration>
                         </plugin>
-			<plugin>
-				<!-- run the integration tests -->
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.18.1</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>integration-test</goal>
-							<goal>verify</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+                        <plugin>
+                                <!-- run the integration tests -->
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-failsafe-plugin</artifactId>
+                                <version>2.18.1</version>
+                                <configuration>
+                                        <skipITs>${skipITs}</skipITs>
+                                </configuration>
+                                <executions>
+                                        <execution>
+                                                <goals>
+                                                        <goal>integration-test</goal>
+                                                        <goal>verify</goal>
+                                                </goals>
+                                        </execution>
+                                </executions>
+                        </plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>

--- a/src/it/java/uk/co/sleonard/unison/UNISoNControllerIT.java
+++ b/src/it/java/uk/co/sleonard/unison/UNISoNControllerIT.java
@@ -13,6 +13,7 @@ import javax.swing.ListModel;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import uk.co.sleonard.unison.datahandling.DAO.NewsGroup;
@@ -20,6 +21,7 @@ import uk.co.sleonard.unison.input.DataHibernatorPoolImpl;
 import uk.co.sleonard.unison.utils.StringUtils;
 
 @Slf4j
+@Ignore("Requires a live NNTP server and is disabled to avoid external network calls")
 public class UNISoNControllerIT {
 	private UNISoNController	controller;
 

--- a/src/it/java/uk/co/sleonard/unison/input/FullDownloadWorkerIT.java
+++ b/src/it/java/uk/co/sleonard/unison/input/FullDownloadWorkerIT.java
@@ -10,6 +10,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import uk.co.sleonard.unison.UNISoNException;
@@ -17,6 +18,7 @@ import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest;
 import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest.DownloadMode;
 import uk.co.sleonard.unison.utils.StringUtils;
 
+@Ignore("Requires a live NNTP server and is disabled to avoid external network calls")
 public class FullDownloadWorkerIT {
 
 	private FullDownloadWorker					worker;

--- a/src/it/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerIT.java
+++ b/src/it/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerIT.java
@@ -13,6 +13,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import org.hibernate.Session;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import uk.co.sleonard.unison.UNISoNException;
@@ -21,6 +22,7 @@ import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest.DownloadMode;
 import uk.co.sleonard.unison.utils.DownloaderImpl;
 import uk.co.sleonard.unison.utils.StringUtils;
 
+@Ignore("Requires a live NNTP server and is disabled to avoid external network calls")
 public class HeaderDownloadWorkerIT {
 
 	public static LinkedBlockingQueue<NewsArticle> populateQueueWithOneRealMessage()

--- a/src/it/java/uk/co/sleonard/unison/input/NewsClientIT.java
+++ b/src/it/java/uk/co/sleonard/unison/input/NewsClientIT.java
@@ -33,6 +33,7 @@ import uk.co.sleonard.unison.utils.StringUtils;
  *
  */
 @Slf4j
+@Ignore("Requires a live NNTP server and is disabled to avoid external network calls")
 public class NewsClientIT {
 
 	public static BufferedReader downloadFirstMessage() throws IOException, UNISoNException {


### PR DESCRIPTION
## Summary
- Marked integration tests depending on `StringUtils.loadServerList()` as ignored to avoid live NNTP connections.
- Configured Maven Failsafe plugin to skip integration tests unless explicitly enabled with `-DskipITs=false`.

## Testing
- `mvn -q verify` *(fails: Plugin org.jacoco:jacoco-maven-plugin could not be resolved, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cf68cbef4832797494f0a92a22aed