### PR TITLE
Refactor UNISoNCLI and add parsing tests

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/input/UNISoNCLI.java
+++ b/src/test/java/uk/co/sleonard/unison/input/UNISoNCLI.java
@@ -8,11 +8,13 @@ package uk.co.sleonard.unison.input;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Optional;
 import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
 import org.hsqldb.util.DatabaseManagerSwing;
 import org.junit.Assert;
+import org.junit.Ignore;
 
 import uk.co.sleonard.unison.UNISoNController;
 import uk.co.sleonard.unison.UNISoNException;
@@ -29,6 +31,7 @@ import uk.co.sleonard.unison.datahandling.DAO.NewsGroup;
  *
  */
 @Slf4j
+@Ignore("Command line entry point - not a unit test")
 public class UNISoNCLI implements UNISoNLogger {
 
 	/**
@@ -37,46 +40,53 @@ public class UNISoNCLI implements UNISoNLogger {
 	 * @param args
 	 *            the arguments
 	 */
-	public static void main(String[] args) {
+        public static void main(String[] args) {
 
-		final UNISoNCLI main = new UNISoNCLI();
-
-		Command command = null;
-		args = new String[] { "QUICKDOWNLOAD", "*ubuntu*" };
-
-		for (final String arg : args) {
-			if (null != command) {
-                                log.info("Run " + command + " with " + arg);
-				try {
-					final String host = "";
-					main.handleCommand(command, arg, host);
-				}
-				catch (final UNISoNException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}
-			}
-			else {
-                                log.debug("arg: " + arg);
-			}
-			try {
-				command = Command.valueOf(arg.toUpperCase());
-			}
-			catch (final IllegalArgumentException e) {
-				// ignore as this just means its not in the enum list
-			}
-		}
-		if (null == command) {
+                final UNISoNCLI main = new UNISoNCLI();
+                final Optional<ParsedArgs> parsed = parseArgs(args);
+                if (parsed.isEmpty()) {
                         log.error("No valid command found in args: {}", Arrays.asList(args));
-			System.exit(1);
-		}
-	};
+                        return;
+                }
+
+                final String host = "";
+                final ParsedArgs p = parsed.get();
+                try {
+                        main.handleCommand(p.command, p.argument, host);
+                }
+                catch (final UNISoNException e) {
+                        log.error("Error executing command", e);
+                }
+        }
 
 	/**
 	 * Instantiates a new UNI so ncli.
 	 */
-	public UNISoNCLI() {
-	}
+        public UNISoNCLI() {
+        }
+
+        static class ParsedArgs {
+                final Command command;
+                final String argument;
+
+                ParsedArgs(final Command command, final String argument) {
+                        this.command = command;
+                        this.argument = argument;
+                }
+        }
+
+        static Optional<ParsedArgs> parseArgs(final String[] args) {
+                if (args == null || args.length < 2) {
+                        return Optional.empty();
+                }
+                try {
+                        final Command command = Command.valueOf(args[0].toUpperCase());
+                        return Optional.of(new ParsedArgs(command, args[1]));
+                }
+                catch (final IllegalArgumentException e) {
+                        return Optional.empty();
+                }
+        }
 
 	/*
 	 * (non-Javadoc)

--- a/src/test/java/uk/co/sleonard/unison/input/UNISoNCLITest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/UNISoNCLITest.java
@@ -1,0 +1,28 @@
+package uk.co.sleonard.unison.input;
+
+import static org.junit.Assert.*;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link UNISoNCLI} argument parsing.
+ */
+public class UNISoNCLITest {
+
+    @Test
+    public void parseArgsReturnsCommandAndArgument() {
+        final Optional<UNISoNCLI.ParsedArgs> parsed = UNISoNCLI.parseArgs(
+                new String[] { "quickdownload", "pattern" });
+        assertTrue(parsed.isPresent());
+        assertEquals(UNISoNCLI.Command.QUICKDOWNLOAD, parsed.get().command);
+        assertEquals("pattern", parsed.get().argument);
+    }
+
+    @Test
+    public void parseArgsReturnsEmptyOnInvalidCommand() {
+        assertFalse(UNISoNCLI.parseArgs(new String[] { "invalid" }).isPresent());
+    }
+}
+


### PR DESCRIPTION
## Summary
- prevent accidental execution of `UNISoNCLI` by marking the class with `@Ignore`
- simplify CLI entry point to parse provided arguments and avoid `System.exit`
- add unit tests verifying CLI argument parsing

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cf72007c883278178be7ec7165b51