### PR TITLE
Add fallback server list and guard test usage

### DIFF
--- a/src/it/java/uk/co/sleonard/unison/UNISoNControllerIT.java
+++ b/src/it/java/uk/co/sleonard/unison/UNISoNControllerIT.java
@@ -30,8 +30,10 @@ public class UNISoNControllerIT {
 
 	@Test
 	public final void testGetAvailableGroupsModel() throws UNISoNException {
-		final Set<NewsGroup> groups = this.controller.listNewsgroups("",
-		        StringUtils.loadServerList()[0], this.controller.getNntpReader().getClient());
+                final String[] servers = StringUtils.loadServerList();
+                Assert.assertTrue("No servers configured", servers.length > 0);
+                final Set<NewsGroup> groups = this.controller.listNewsgroups("", servers[0],
+                        this.controller.getNntpReader().getClient());
 		final ListModel<NewsGroup> model = this.controller.getAvailableGroupsModel(groups);
 		final NewsGroup firstGroup = model.getElementAt(0);
 		Assert.assertNotNull(firstGroup);
@@ -41,8 +43,10 @@ public class UNISoNControllerIT {
 
 	@Test
 	public final void testListnewsgroups() throws UNISoNException {
-		final Set<NewsGroup> groups = this.controller.listNewsgroups("",
-		        StringUtils.loadServerList()[0], this.controller.getNntpReader().getClient());
+                final String[] servers = StringUtils.loadServerList();
+                Assert.assertTrue("No servers configured", servers.length > 0);
+                final Set<NewsGroup> groups = this.controller.listNewsgroups("", servers[0],
+                        this.controller.getNntpReader().getClient());
 		Assert.assertTrue(groups.size() > 0);
 		log.info("Found " + groups.size());
 

--- a/src/it/java/uk/co/sleonard/unison/input/FullDownloadWorkerIT.java
+++ b/src/it/java/uk/co/sleonard/unison/input/FullDownloadWorkerIT.java
@@ -24,12 +24,14 @@ public class FullDownloadWorkerIT {
 
 	@Before
 	public void setUp() throws Exception {
-		final String server = StringUtils.loadServerList()[0];
-		this.outQueue = HeaderDownloadWorkerIT.populateQueueWithOneRealMessage();
+                final String[] servers = StringUtils.loadServerList();
+                Assert.assertTrue("No servers configured", servers.length > 0);
+                final String server = servers[0];
+                this.outQueue = HeaderDownloadWorkerIT.populateQueueWithOneRealMessage();
 
-		final NewsClient newsClient = new NewsClientImpl();
-		this.worker = new FullDownloadWorker(server, this.outQueue, newsClient);
-	}
+                final NewsClient newsClient = new NewsClientImpl();
+                this.worker = new FullDownloadWorker(server, this.outQueue, newsClient);
+        }
 
 	@Test
 	public final void testDownloadArticleHeaders() throws UNISoNException, InterruptedException {

--- a/src/it/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerIT.java
+++ b/src/it/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerIT.java
@@ -27,7 +27,9 @@ public class HeaderDownloadWorkerIT {
 	        throws IOException, UNISoNException {
 		final LinkedBlockingQueue<NewsArticle> queue = new LinkedBlockingQueue<>();
 		try (final Reader reader = NewsClientIT.downloadFirstMessage();) {
-			final String nntpHost = StringUtils.loadServerList()[0];
+                        final String[] servers = StringUtils.loadServerList();
+                        Assert.assertTrue("No servers configured", servers.length > 0);
+                        final String nntpHost = servers[0];
 			final LinkedBlockingQueue<NewsArticle> queue1 = new LinkedBlockingQueue<>();
 			final NewsClient newsClient1 = new NewsClientImpl();
 			final HibernateHelper helper2 = null;

--- a/src/it/java/uk/co/sleonard/unison/input/NewsClientIT.java
+++ b/src/it/java/uk/co/sleonard/unison/input/NewsClientIT.java
@@ -36,7 +36,9 @@ import uk.co.sleonard.unison.utils.StringUtils;
 public class NewsClientIT {
 
 	public static BufferedReader downloadFirstMessage() throws IOException, UNISoNException {
-		return NewsClientIT.downloadFirstMessage(StringUtils.loadServerList()[0]);
+                final String[] servers = StringUtils.loadServerList();
+                Assert.assertTrue("No servers configured", servers.length > 0);
+                return NewsClientIT.downloadFirstMessage(servers[0]);
 	}
 
 	public static BufferedReader downloadFirstMessage(final String server)
@@ -84,8 +86,10 @@ public class NewsClientIT {
 
 	@Test
 	public void testRetrieveArticleInfo() throws Exception {
-		final String server = StringUtils.loadServerList()[0];
-		final BufferedReader reader = NewsClientIT.downloadFirstMessage(server);
+                final String[] servers = StringUtils.loadServerList();
+                Assert.assertTrue("No servers configured", servers.length > 0);
+                final String server = servers[0];
+                final BufferedReader reader = NewsClientIT.downloadFirstMessage(server);
 		try (final BufferedReader bufReader = new BufferedReader(reader);) {
 			final String line = bufReader.readLine();
 			log.info("Message: " + line);

--- a/src/main/java/uk/co/sleonard/unison/utils/StringUtils.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/StringUtils.java
@@ -52,6 +52,9 @@ public class StringUtils {
         /** Logger for this class. */
         private static final Logger LOG = LoggerFactory.getLogger(StringUtils.class);
 
+        /** Default server list used when no properties file is found. */
+        private static final String[] DEFAULT_SERVERS = { "news.karlsruhe.org" };
+
         static final String[] DATE_SEPARATORS = { "/", "-", ".", "," };
 
 	/**
@@ -203,15 +206,17 @@ public class StringUtils {
 
                 final String file = "servers.properties";
 
-                try (final InputStream resources = ClassLoader.getSystemResourceAsStream(file);) {
-                        if (null == resources) {
-                                throw new IOException("can't find " + file);
+                try (final InputStream resources = StringUtils.class.getClassLoader()
+                                .getResourceAsStream(file);) {
+                        if (resources != null) {
+                                return loadServerList(resources);
                         }
-                        return loadServerList(resources);
+                        LOG.warn("Server list file '{}' not found, using default server list", file);
+                        return DEFAULT_SERVERS;
                 }
                 catch (final IOException io) {
                         LOG.error("Unable to load server list", io);
-                        return new String[0];
+                        return DEFAULT_SERVERS;
                 }
         }
 

--- a/src/main/resources/servers.properties
+++ b/src/main/resources/servers.properties
@@ -1,1 +1,2 @@
 servers=news.karlsruhe.org,news.tin.org,news.newsgroup.la,news.povray.org,news.uni-koblenz.de
+

--- a/src/test/java/uk/co/sleonard/unison/input/FullDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/FullDownloadWorkerTest.java
@@ -48,11 +48,12 @@ public class FullDownloadWorkerTest {
 	 */
 	@Before
 	public void setUp() throws Exception {
-		this.newsClient = Mockito.mock(NewsClient.class);
-		this.outQueue = new LinkedBlockingQueue<>();
-		this.worker = new FullDownloadWorker(StringUtils.loadServerList()[0], this.outQueue,
-		        this.newsClient);
-	}
+                this.newsClient = Mockito.mock(NewsClient.class);
+                this.outQueue = new LinkedBlockingQueue<>();
+                final String[] servers = StringUtils.loadServerList();
+                Assert.assertTrue("No servers configured", servers.length > 0);
+                this.worker = new FullDownloadWorker(servers[0], this.outQueue, this.newsClient);
+        }
 
 	/**
 	 * Test AddDownloadRequest.
@@ -116,8 +117,10 @@ public class FullDownloadWorkerTest {
 	public void testConstruct() {
 		FullDownloadWorker actual;
 		try {
-			actual = new FullDownloadWorker(StringUtils.loadServerList()[0],
-			        new LinkedBlockingQueue(), this.newsClient);
+                        final String[] servers = StringUtils.loadServerList();
+                        Assert.assertTrue("No servers configured", servers.length > 0);
+                        actual = new FullDownloadWorker(servers[0], new LinkedBlockingQueue(),
+                                this.newsClient);
 			Assert.assertNotNull(actual);
 		}
 		catch (final UNISoNException e) {

--- a/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
@@ -90,7 +90,9 @@ public class HeaderDownloadWorkerTest {
 		final Date fromAndTo = Calendar.getInstance().getTime();
 		Assert.assertFalse(this.worker.isDownloading());
 
-		final String server = StringUtils.loadServerList()[0];
+                final String[] servers = StringUtils.loadServerList();
+                Assert.assertTrue("No servers configured", servers.length > 0);
+                final String server = servers[0];
 
 		this.worker.initialise(ngr, 0, 1, server, "newsgroup", uniLog, DownloadMode.ALL, fromAndTo,
 		        fromAndTo);

--- a/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
+++ b/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
@@ -92,10 +92,11 @@ public class StringUtilsTest {
 	}
 
 	/**
-	 * Test loadServerList
-	 */
-	@Test
+        * Test loadServerList
+        */
+        @Test
         public void testLoadServerList() {
+                assertNotNull(StringUtils.class.getClassLoader().getResource("servers.properties"));
                 String[] actual = StringUtils.loadServerList();
                 assertNotNull(actual);
                 assertTrue(actual.length > 0);


### PR DESCRIPTION
## Summary
- ensure servers.properties is available on test classpath
- provide default NNTP server when servers.properties is missing
- guard tests against empty server list access

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.12 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cf725c34c83278dcf375a21986112