### PR TITLE
chore: specify maven compiler plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,14 +71,15 @@
 					</archive>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
-			</plugin>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-compiler-plugin</artifactId>
+                                <version>3.11.0</version>
+                                <configuration>
+                                        <source>${java.version}</source>
+                                        <target>${java.version}</target>
+                                </configuration>
+                        </plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>


### PR DESCRIPTION
## Summary
- add explicit version for maven-compiler-plugin to remove build warning

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cfbbd9ac08327b3eeef4059562275

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/235)
<!-- Reviewable:end -->
