### PR TITLE
chore: use https-compatible jaxb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,10 +294,18 @@
                         <version>${jakarta.mail.version}</version>
                 </dependency>
 
-		<dependency>
-			<groupId>org.jacoco</groupId>
-			<artifactId>jacoco-maven-plugin</artifactId>
-			<version>${jacoco.version}</version>
+                <!-- Replace legacy JAXB reference that required an HTTP repository with a
+                     version available on Maven Central over HTTPS -->
+                <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.3.1</version>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.version}</version>
 			<type>maven-plugin</type>
 		</dependency>
                 <dependency>


### PR DESCRIPTION
## Summary
- replace legacy javax.xml.bind:jaxb-api pre-release with 2.3.1 from Maven Central

## Testing
- `mvn -q -e -DskipTests install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cfbbf3b888327a7a6821bb06b0e73

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/236)
<!-- Reviewable:end -->
