### PR TITLE
Specify jar plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
+                                <version>3.3.0</version>
 				<configuration>
 					<archive>
 						<manifest>


### PR DESCRIPTION
## Summary
- explicitly set maven-jar-plugin version to 3.3.0 in pom

## Testing
- `mvn -q test` *(fails: Could not resolve org.jacoco:jacoco-maven-plugin:0.8.12 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cfbbc96e08327b346ea31c06df8b3