### PR TITLE
fix: use central coordinates for hsqldb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,11 +234,11 @@
 			<version>${hibernate-tools.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-			<version>${hsqldb.version}</version>
-		</dependency>
+                <dependency>
+                        <groupId>org.hsqldb</groupId>
+                        <artifactId>hsqldb</artifactId>
+                        <version>${hsqldb.version}</version>
+                </dependency>
 
 		<!-- <dependency> <groupId>gnu.classpath.ext</groupId> <artifactId>inetlib</artifactId> 
 			<version>1.1.1</version> </dependency> -->


### PR DESCRIPTION
## Summary
- use `org.hsqldb` as the groupId for the HSQLDB dependency so it resolves from Maven Central

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.12 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cff4791308327850db7728b77afd6

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/238)
<!-- Reviewable:end -->
