### PR TITLE
Use JAXB libraries from Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,21 @@
                 <jakarta.mail.version>2.1.3</jakarta.mail.version>
                 <skipITs>true</skipITs>
         </properties>
+        <dependencyManagement>
+                <dependencies>
+                        <dependency>
+                                <groupId>javax.xml.bind</groupId>
+                                <artifactId>jaxb-api</artifactId>
+                                <version>2.3.1</version>
+                        </dependency>
+                        <dependency>
+                                <groupId>org.glassfish.jaxb</groupId>
+                                <artifactId>jaxb-runtime</artifactId>
+                                <version>2.3.7</version>
+                        </dependency>
+                </dependencies>
+        </dependencyManagement>
+
 
 	<build>
 		<plugins>
@@ -302,6 +317,12 @@
                         <groupId>javax.xml.bind</groupId>
                         <artifactId>jaxb-api</artifactId>
                         <version>2.3.1</version>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.glassfish.jaxb</groupId>
+                        <artifactId>jaxb-runtime</artifactId>
+                        <version>2.3.7</version>
                 </dependency>
 
                 <dependency>


### PR DESCRIPTION
## Summary
- manage JAXB dependencies and upgrade to versions hosted on Maven Central
- add `org.glassfish.jaxb:jaxb-runtime` to project dependencies

## Testing
- `mvn -q -e package` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.12 from/to central (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_689cff42f5088327a0ecd8d2de2a2685