### PR TITLE
Downgrade Hibernate dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
                 <maven-jxr-plugin.version>3.3.1</maven-jxr-plugin.version>
                 <webstart-maven-plugin.version>1.0.0</webstart-maven-plugin.version>
 
-                <hibernate-core.version>5.6.20.Final</hibernate-core.version>
-                <hibernate-tools.version>5.6.20.Final</hibernate-tools.version>
+                <hibernate-core.version>5.6.15.Final</hibernate-core.version>
+                <hibernate-tools.version>5.6.15.Final</hibernate-tools.version>
                 <hsqldb.version>2.7.3</hsqldb.version>
                 <jung.version>1.7.6</jung.version>
                 <ehcache.version>3.10.8</ehcache.version>


### PR DESCRIPTION
## Summary
- use Hibernate 5.6.15.Final for core and tools

## Testing
- `mvn -U clean install` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e110183a48327ae896183585fb7bc