### PR TITLE
chore: downgrade swing-layout to 1.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
                 <hsqldb.version>2.7.3</hsqldb.version>
                 <jung.version>1.7.6</jung.version>
                 <ehcache.version>3.10.8</ehcache.version>
-                <swing-layout.version>1.0.4</swing-layout.version>
+                <swing-layout.version>1.0.3</swing-layout.version>
                 <jakarta.mail.version>2.1.3</jakarta.mail.version>
                 <skipITs>true</skipITs>
         </properties>


### PR DESCRIPTION
## Summary
- use swing-layout 1.0.3

## Testing
- `mvn clean install` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e483cb5bc832794a1c7de37044e5e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/242)
<!-- Reviewable:end -->
