### PR TITLE
Split Jakarta Mail dependency into API and implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
                 <jung.version>1.7.6</jung.version>
                 <ehcache.version>3.10.8</ehcache.version>
                 <swing-layout.version>1.0.4</swing-layout.version>
-                <jakarta.mail.version>2.1.3</jakarta.mail.version>
                 <skipITs>true</skipITs>
         </properties>
         <dependencyManagement>
@@ -305,12 +304,16 @@
                 </dependency>
 
 
-                <!-- gnumail lib not found. Then we checked that the package used is (jakarta.mail).
-                        So, we have added its dependency -->
+                <!-- Jakarta Mail API and implementation -->
+                <dependency>
+                        <groupId>jakarta.mail</groupId>
+                        <artifactId>jakarta.mail-api</artifactId>
+                        <version>2.1.3</version>
+                </dependency>
                 <dependency>
                         <groupId>com.sun.mail</groupId>
                         <artifactId>jakarta.mail</artifactId>
-                        <version>${jakarta.mail.version}</version>
+                        <version>2.0.1</version>
                 </dependency>
 
                 <!-- Replace legacy JAXB reference that required an HTTP repository with a


### PR DESCRIPTION
## Summary
- remove old Jakarta Mail dependency
- add separate API (2.1.3) and implementation (2.0.1) dependencies

## Testing
- `mvn clean install` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_689e483bd814832795a6d44f3b8dec54

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/243)
<!-- Reviewable:end -->
