### PR TITLE
Fix UsenetUser copy constructor

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/datahandling/DAO/UsenetUser.java
+++ b/src/main/java/uk/co/sleonard/unison/datahandling/DAO/UsenetUser.java
@@ -71,14 +71,12 @@ public class UsenetUser implements java.io.Serializable {
         this.location = location;
     }
     public UsenetUser(final UsenetUser poster) {
-        new UsenetUserBuilder()
-                .email(poster.getEmail())
-                .id(poster.getId())
-                .location(poster.getLocation())
-                .name(poster.getName())
-                .gender(poster.getGender())
-                .ipaddress(poster.getIpaddress())
-                .build();
+        this.name = poster.getName();
+        this.email = poster.getEmail();
+        this.ipaddress = poster.getIpaddress();
+        this.gender = poster.getGender();
+        this.location = poster.getLocation();
+        this.id = poster.getId();
     }
     @Override
     public String toString() {

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/UsenetUserTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/UsenetUserTest.java
@@ -32,8 +32,8 @@ public class UsenetUserTest {
 	 * Test Constructor
 	 */
 	@Test
-	public void testConstructor() {
-		UsenetUser actual = null;
+        public void testConstructor() {
+                UsenetUser actual = null;
 		final String expected = "John";
 		final String expected2 = "john@java.com";
 		final String expected3 = "127.0.0.1";
@@ -44,8 +44,26 @@ public class UsenetUserTest {
 		Assert.assertEquals(expected2, actual.getEmail());
 		Assert.assertEquals(expected3, actual.getIpaddress());
 		Assert.assertEquals(expected4, actual.getGender());
-		Assert.assertEquals(expected5, actual.getLocation());
-	}
+                Assert.assertEquals(expected5, actual.getLocation());
+        }
+
+        /**
+         * Test copy constructor.
+         */
+        @Test
+        public void testCopyConstructor() {
+                final Location location = new Location();
+                final UsenetUser original = new UsenetUser("John", "john@java.com", "127.0.0.1", "Programming", location);
+                original.setId(123);
+
+                final UsenetUser copy = new UsenetUser(original);
+                Assert.assertEquals(original.getName(), copy.getName());
+                Assert.assertEquals(original.getEmail(), copy.getEmail());
+                Assert.assertEquals(original.getIpaddress(), copy.getIpaddress());
+                Assert.assertEquals(original.getGender(), copy.getGender());
+                Assert.assertEquals(original.getLocation(), copy.getLocation());
+                Assert.assertEquals(original.getId(), copy.getId());
+        }
 
 	/**
 	 * Test getEmail.


### PR DESCRIPTION
## Summary
- fix `UsenetUser` copy constructor to copy all fields
- add unit test verifying copy constructor copies values

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689e54f0459c8327bd7324576f9569f9

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/244)
<!-- Reviewable:end -->
