### PR TITLE
Configure Lombok annotation processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
                 <java.version>17</java.version>
         <powermock.version>2.0.9</powermock.version>
         <mockito.version>5.12.0</mockito.version>
+        <lombok.version>1.18.30</lombok.version>
                 <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
                 <jacoco.version>0.8.12</jacoco.version>
                 <jms.version>3.1.0</jms.version>
@@ -96,6 +97,13 @@
                                 <configuration>
                                         <source>${java.version}</source>
                                         <target>${java.version}</target>
+                                        <annotationProcessorPaths>
+                                                <path>
+                                                        <groupId>org.projectlombok</groupId>
+                                                        <artifactId>lombok</artifactId>
+                                                        <version>${lombok.version}</version>
+                                                </path>
+                                        </annotationProcessorPaths>
                                 </configuration>
                         </plugin>
 			<plugin>
@@ -344,12 +352,12 @@
                 </dependency>
 
     <dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.30</version>
-			<scope>compile</scope>
-		</dependency>
-	</dependencies>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>${lombok.version}</version>
+                        <scope>compile</scope>
+                </dependency>
+        </dependencies>
     
 	<reporting>
 		<plugins>


### PR DESCRIPTION
## Summary
- supply Lombok to the `maven-compiler-plugin` annotation processor path
- centralize Lombok version via project property

## Testing
- `mvn -q test` *(fails: Could not resolve org.jacoco:jacoco-maven-plugin due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e54ef47648327823d608bce48aae5