### PR TITLE
Handle null results in UNISoNDatabase

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/datahandling/UNISoNDatabase.java
+++ b/src/main/java/uk/co/sleonard/unison/datahandling/UNISoNDatabase.java
@@ -44,23 +44,35 @@ public class UNISoNDatabase extends Observable {
 	 *            the session
 	 * @return the messages
 	 */
-	public Set<Message> getMessages(final Topic topic, final Session session1) {
-		final String query = "from  Message  where topic_id = " + topic.getId();
-		final HashSet<Message> returnVal = new HashSet<>();
-		final List<Message> results = this.helper.runQuery(query, session1, Message.class);
-		for (final Message message1 : results) {
-			if (((null == this.filter.getSelectedMessages())
-			        || (this.filter.getSelectedMessages().size() == 0)
-			        || this.filter.getSelectedMessages().contains(message1))
-			        && ((null == this.filter.getSelectedPosters())
-			                || (this.filter.getSelectedPosters().size() == 0)
-			                || this.filter.getSelectedPosters().contains(message1.getPoster()))) {
-				returnVal.add(message1);
-			}
-		}
+        public Set<Message> getMessages(final Topic topic, final Session session1) {
+                final String query = "from  Message  where topic_id = " + topic.getId();
+                final HashSet<Message> returnVal = new HashSet<>();
+                List<Message> results = null;
+                try {
+                        results = this.helper.runQuery(query, session1, Message.class);
+                }
+                catch (final Exception e) {
+                        log.warn("Failed to run query {}", query, e);
+                        return returnVal;
+                }
 
-		return returnVal;
-	}
+                if ((results == null) || results.isEmpty()) {
+                        return returnVal;
+                }
+
+                for (final Message message1 : results) {
+                        if (((null == this.filter.getSelectedMessages())
+                                || (this.filter.getSelectedMessages().size() == 0)
+                                || this.filter.getSelectedMessages().contains(message1))
+                                && ((null == this.filter.getSelectedPosters())
+                                        || (this.filter.getSelectedPosters().size() == 0)
+                                        || this.filter.getSelectedPosters().contains(message1.getPoster()))) {
+                                returnVal.add(message1);
+                        }
+                }
+
+                return returnVal;
+        }
 
 	/*
 	 * (non-Javadoc)


### PR DESCRIPTION
## Summary
- Safeguard message retrieval against null or empty query results
- Catch query exceptions and return an empty set when retrieval fails

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f92ef7dd0832793d786a2d1e5d7a5

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/250)
<!-- Reviewable:end -->
