### PR TITLE
Preserve cause when reconnect fails

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/input/NewsClientImpl.java
+++ b/src/main/java/uk/co/sleonard/unison/input/NewsClientImpl.java
@@ -233,18 +233,24 @@ public class NewsClientImpl implements NewsClient {
 	 * @throws UNISoNException
 	 *             the UNI so n exception
 	 */
-	@Override
-	public void reconnect() throws UNISoNException {
-		// If it should be connected but has timed out
-		if (!this.isConnected()) {
-			try {
-				this.connect(this.host);
-			}
-			catch (final IOException e) {
-				throw new UNISoNException("Failed to connect", e);
-			}
-		}
-	}
+        @Override
+        public void reconnect() throws UNISoNException {
+                // If it should be connected but has timed out
+                if (!this.isConnected()) {
+                        try {
+                                this.connect(this.host);
+                        }
+                        catch (final SocketException e) {
+                                // preserve the original socket exception as the cause
+                                throw new UNISoNException("Failed to connect", e);
+                        }
+                        catch (final IOException e) {
+                                // retain the root cause of the IOException where possible
+                                final Throwable cause = (e.getCause() != null) ? e.getCause() : e;
+                                throw new UNISoNException("Failed to connect", cause);
+                        }
+                }
+        }
 
 	@Override
 	public Reader retrieveArticle(final String articleId) throws IOException {


### PR DESCRIPTION
## Summary
- ensure `reconnect` wraps `SocketException`/`IOException` in `UNISoNException` while preserving the original cause

## Testing
- `mvn test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f92ecbdd48327a8eddb54e6412167

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/251)
<!-- Reviewable:end -->
