### PR TITLE
Use in-memory HSQLDB for tests

### DIFF
--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -7,9 +7,9 @@
 		<property name="hibernate.connection.driver_class">
 			org.hsqldb.jdbcDriver
 		</property>
-		<property name="hibernate.connection.url">
-			jdbc:hsqldb:file:src/main/resources/DB/projectDB
-		</property>
+                <property name="hibernate.connection.url">
+                        jdbc:hsqldb:mem:testdb
+                </property>
 		<property name="hibernate.connection.username">SA</property>
 		<property name="hibernate.dialect">
 			org.hibernate.dialect.HSQLDialect
@@ -24,11 +24,14 @@
 			false
 		</property>
 
-		<!-- JDBC connection pool (use the built-in) -->
-		<property name="hibernate.connection.pool_size">20</property>
+                <!-- JDBC connection pool (use the built-in) -->
+                <property name="hibernate.connection.pool_size">20</property>
 
-		<!-- Echo all executed SQL to stdout -->
-		<property name="hibernate.show_sql">false</property>
+                <!-- Create schema for tests on startup -->
+                <property name="hibernate.hbm2ddl.auto">create</property>
+
+                <!-- Echo all executed SQL to stdout -->
+                <property name="hibernate.show_sql">false</property>
 		<mapping resource="dao/Topic.hbm.xml" />
 		<mapping resource="dao/NewsGroup.hbm.xml" />
                 <mapping resource="dao/Message.hbm.xml" />

--- a/src/main/resources/hibernate.properties
+++ b/src/main/resources/hibernate.properties
@@ -1,8 +1,9 @@
 hibernate.connection.driver_class=org.hsqldb.jdbcDriver
-hibernate.connection.url=jdbc:hsqldb:file:src/main/resources/DB/projectDB
+hibernate.connection.url=jdbc:hsqldb:mem:testdb
 hibernate.connection.username=SA
 hibernate.connection.password=
 hibernate.connection.pool_size=2
 hibernate.dialect=org.hibernate.dialect.HSQLDialect
 hibernate.cache.provider_class=org.hibernate.cache.OSCacheProvider
+hibernate.hbm2ddl.auto=create
 hibernate.connection.autocommit=true

--- a/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperRunQueryTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperRunQueryTest.java
@@ -4,7 +4,9 @@ import static org.junit.Assert.*;
 
 import java.util.Map;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Vector;
+import java.util.Date;
 
 import org.hibernate.Session;
 import org.junit.After;
@@ -13,6 +15,8 @@ import org.junit.Test;
 
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.datahandling.DAO.Message;
+import uk.co.sleonard.unison.datahandling.DAO.Topic;
+import uk.co.sleonard.unison.datahandling.DAO.UsenetUser;
 
 public class HibernateHelperRunQueryTest {
 
@@ -23,6 +27,17 @@ public class HibernateHelperRunQueryTest {
     public void setUp() throws UNISoNException {
         this.helper = new HibernateHelper(null);
         this.session = this.helper.getHibernateSession();
+
+        // Seed the in-memory database with a single message
+        this.session.beginTransaction();
+        UsenetUser poster = new UsenetUser("poster", "poster@example.com", "127.0.0.1", null, null);
+        this.session.save(poster);
+        Topic topic = new Topic("topic", new HashSet<>());
+        this.session.save(topic);
+        Message msg = new Message(new Date(), "msg-1", "Duke Nukem Hall of Shame (update)", poster, topic,
+                new HashSet<>(), null, null);
+        this.session.save(msg);
+        this.session.getTransaction().commit();
     }
 
     @After


### PR DESCRIPTION
## Summary
- point Hibernate configs to in-memory `jdbc:hsqldb:mem:testdb`
- auto-create schema via `hibernate.hbm2ddl.auto`
- seed an in-memory dataset for `HibernateHelperRunQueryTest`

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689f92f3ed84832792d5ade40bbc8c07

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/252)
<!-- Reviewable:end -->
