### PR TITLE
Avoid Lombok @Data recursion in DAO entities

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/datahandling/DAO/NewsGroup.java
+++ b/src/main/java/uk/co/sleonard/unison/datahandling/DAO/NewsGroup.java
@@ -7,11 +7,13 @@
 package uk.co.sleonard.unison.datahandling.DAO;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.apache.commons.net.nntp.NewsgroupInfo;
 
 /**
@@ -21,7 +23,8 @@ import org.apache.commons.net.nntp.NewsgroupInfo;
  * @since Generated 11-Nov-2007 17:31:30
  *
  */
-@Data
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class NewsGroup implements java.io.Serializable, Comparable<NewsGroup> {
@@ -89,13 +92,30 @@ private String fullName;
 	 *
 	 * @return true, if is last node
 	 */
-	public boolean isLastNode() {
-		return this.lastNode;
-	}
+        public boolean isLastNode() {
+                return this.lastNode;
+        }
 
-	@Override
-	public String toString() {
-		return this.getFullName() + "(" + this.getArticleCount() + ")";
-	}
+        @Override
+        public boolean equals(final Object obj) {
+                if (this == obj) {
+                        return true;
+                }
+                if (!(obj instanceof NewsGroup)) {
+                        return false;
+                }
+                final NewsGroup other = (NewsGroup) obj;
+                return this.id == other.id && Objects.equals(this.name, other.name);
+        }
+
+        @Override
+        public int hashCode() {
+                return Objects.hash(this.id, this.name);
+        }
+
+        @Override
+        public String toString() {
+                return this.getFullName() + "(" + this.getArticleCount() + ")";
+        }
 
 }

--- a/src/main/java/uk/co/sleonard/unison/datahandling/DAO/Topic.java
+++ b/src/main/java/uk/co/sleonard/unison/datahandling/DAO/Topic.java
@@ -6,11 +6,13 @@
  */
 package uk.co.sleonard.unison.datahandling.DAO;
 
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Represents a message thread.
@@ -19,7 +21,8 @@ import java.util.Set;
  * @since Generated 11-Nov-2007 17:31:30
  *
  */
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 public class Topic implements java.io.Serializable {
 	private static final long serialVersionUID = -4646650675535168051L;
@@ -40,14 +43,31 @@ public class Topic implements java.io.Serializable {
 		this.newsgroups = newsgroups;
 	}
 
-	public Topic(final Topic topic) {
-		this(topic.subject, topic.newsgroups);
-		this.id = topic.id;
-	}
+        public Topic(final Topic topic) {
+                this(topic.subject, topic.newsgroups);
+                this.id = topic.id;
+        }
 
-	@Override
-	public String toString() {
-		return this.getSubject();
-	}
+        @Override
+        public boolean equals(final Object obj) {
+                if (this == obj) {
+                        return true;
+                }
+                if (!(obj instanceof Topic)) {
+                        return false;
+                }
+                final Topic other = (Topic) obj;
+                return this.id == other.id && Objects.equals(this.subject, other.subject);
+        }
+
+        @Override
+        public int hashCode() {
+                return Objects.hash(this.id, this.subject);
+        }
+
+        @Override
+        public String toString() {
+                return this.getSubject();
+        }
 
 }


### PR DESCRIPTION
## Summary
- Replace @Data with @Getter/@Setter in NewsGroup and Topic
- Implement explicit equals and hashCode methods to avoid bidirectional recursion

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f92eb89d4832789f3fe80f503d37c