### PR TITLE
Use shared Hibernate configuration in persistence test

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/UsenetUserPersistenceTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/UsenetUserPersistenceTest.java
@@ -6,6 +6,7 @@ import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
+import java.util.Collections;
 
 /**
  * Regression test to ensure {@link UsenetUser} can be persisted using annotations.
@@ -14,19 +15,22 @@ public class UsenetUserPersistenceTest {
 
     @Test
     public void testPersistAndLoad() {
-        Configuration cfg = new Configuration();
-        cfg.setProperty("hibernate.connection.driver_class", "org.hsqldb.jdbcDriver");
+        Configuration cfg = new Configuration().configure();
         cfg.setProperty("hibernate.connection.url", "jdbc:hsqldb:mem:usenetuser;DB_CLOSE_DELAY=-1");
-        cfg.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
         cfg.setProperty("hibernate.hbm2ddl.auto", "create-drop");
-        cfg.setProperty("hibernate.show_sql", "false");
-        cfg.addAnnotatedClass(UsenetUser.class);
-        cfg.addResource("dao/Location.hbm.xml");
 
         try (SessionFactory sf = cfg.buildSessionFactory();
              Session session = sf.openSession()) {
+            Assert.assertNotNull(sf.getClassMetadata(Location.class));
+            Assert.assertNotNull(sf.getClassMetadata(IpAddress.class));
             Transaction tx = session.beginTransaction();
-            UsenetUser user = new UsenetUser("Test", "test@example.com", "127.0.0.1", "male", null);
+            Location location = new Location("City", "Country", "CC", false,
+                    Collections.emptyList(), Collections.emptyList());
+            session.save(location);
+            IpAddress ip = new IpAddress("127.0.0.1", location);
+            session.save(ip);
+            UsenetUser user = new UsenetUser("Test", "test@example.com", "127.0.0.1", "male",
+                    location);
             session.save(user);
             tx.commit();
 
@@ -34,6 +38,7 @@ public class UsenetUserPersistenceTest {
             UsenetUser fromDb = session.get(UsenetUser.class, user.getId());
             Assert.assertNotNull(fromDb);
             Assert.assertEquals("test@example.com", fromDb.getEmail());
+            Assert.assertEquals("City", fromDb.getLocation().getCity());
         }
     }
 }


### PR DESCRIPTION
## Summary
- verify SessionFactory uses main `hibernate.cfg.xml` so DAO mappings are applied
- persist `Location` and `IpAddress` entities in test to ensure mappings load

## Testing
- `mvn -q -Djacoco.skip=true test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689f92e82110832789f50245f1b40c82