### PR TITLE
Initialize GUI earlier and guard alert calls

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/UNISoNController.java
+++ b/src/main/java/uk/co/sleonard/unison/UNISoNController.java
@@ -80,12 +80,11 @@ public class UNISoNController {
 
 	private NewsClient client;
 
-	public static UNISoNController create(final JFrame frame, final DataHibernatorPool pool)
-	        throws UNISoNException {
-		UNISoNController.instance = new UNISoNController(pool);
-		UNISoNController.instance.setGui(new UNISoNGUI(frame));
-		return UNISoNController.instance;
-	}
+        public static UNISoNController create(final JFrame frame, final DataHibernatorPool pool)
+                throws UNISoNException {
+                UNISoNController.instance = new UNISoNController(frame, pool);
+                return UNISoNController.instance;
+        }
 	// private static UNISoNController instance;
 
 	/**
@@ -102,26 +101,30 @@ public class UNISoNController {
 	 *
 	 * @throws UNISoNException
 	 */
-	private UNISoNController(final DataHibernatorPool hibernatorPool) throws UNISoNException {
-		this.pool = hibernatorPool;
+        private UNISoNController(final JFrame frame, final DataHibernatorPool hibernatorPool)
+                throws UNISoNException {
+                this.pool = hibernatorPool;
+                this.gui = (frame != null) ? new UNISoNGUI(frame) : null;
 
-		this.messageQueue = new LinkedBlockingQueue<>();
-		this.helper = new HibernateHelper(this.gui);
-		try {
-			final Session hibernateSession = this.getHelper().getHibernateSession();
-			this.setSession(hibernateSession);
-			this.filter = new NewsGroupFilter(hibernateSession, this.helper);
-			this.analysis = new UNISoNAnalysis(this.filter, hibernateSession, this.helper);
-			this.database = new UNISoNDatabase(this.filter, hibernateSession, this.helper,
-			        new DataQuery(this.helper));
-		}
-		catch (final UNISoNException e) {
-			this.getGui().showAlert("Error:" + e.getMessage());
-			throw e;
-		}
+                this.messageQueue = new LinkedBlockingQueue<>();
+                this.helper = new HibernateHelper(this.gui);
+                try {
+                        final Session hibernateSession = this.getHelper().getHibernateSession();
+                        this.setSession(hibernateSession);
+                        this.filter = new NewsGroupFilter(hibernateSession, this.helper);
+                        this.analysis = new UNISoNAnalysis(this.filter, hibernateSession, this.helper);
+                        this.database = new UNISoNDatabase(this.filter, hibernateSession, this.helper,
+                                new DataQuery(this.helper));
+                }
+                catch (final UNISoNException e) {
+                        if (this.getGui() != null) {
+                                this.getGui().showAlert("Error:" + e.getMessage());
+                        }
+                        throw e;
+                }
 
-		this.nntpReader = new NewsGroupReader(this);
-	}
+                this.nntpReader = new NewsGroupReader(this);
+        }
 
 	public void cancel() {
 		this.getHeaderDownloader().fullstop();

--- a/src/main/java/uk/co/sleonard/unison/gui/generated/DownloadNewsPanel.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/DownloadNewsPanel.java
@@ -156,8 +156,10 @@ public class DownloadNewsPanel extends javax.swing.JPanel
 	 */
 	@Override
 	public void alert(final String message) {
-		this.log(message);
-		this.controller.getGui().showAlert(message);
+                this.log(message);
+                if (this.controller.getGui() != null) {
+                        this.controller.getGui().showAlert(message);
+                }
 	}
 
 	/**

--- a/src/main/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewer.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewer.java
@@ -191,9 +191,11 @@ class MessageStoreViewer extends javax.swing.JPanel implements Observer, UNISoNL
 
 			this.switchFilter(this.filterToggle.isSelected());
 		}
-		catch (final UNISoNException e) {
-			this.controller.getGui().showAlert("Error :" + e.getMessage());
-		}
+                catch (final UNISoNException e) {
+                        if (this.controller.getGui() != null) {
+                                this.controller.getGui().showAlert("Error :" + e.getMessage());
+                        }
+                }
 	}
 
 	/**
@@ -238,8 +240,10 @@ class MessageStoreViewer extends javax.swing.JPanel implements Observer, UNISoNL
 	 */
 	@Override
 	public void alert(final String message) {
-		this.log(message);
-		this.controller.getGui().showAlert(message);
+                this.log(message);
+                if (this.controller.getGui() != null) {
+                        this.controller.getGui().showAlert(message);
+                }
 	}
 
 	/**
@@ -339,9 +343,11 @@ class MessageStoreViewer extends javax.swing.JPanel implements Observer, UNISoNL
 		try {
 			this.switchFilter(this.filterToggle.isSelected());
 		}
-		catch (final UNISoNException e) {
-			this.controller.getGui().showAlert("Error :" + e.getMessage());
-		}
+                catch (final UNISoNException e) {
+                        if (this.controller.getGui() != null) {
+                                this.controller.getGui().showAlert("Error :" + e.getMessage());
+                        }
+                }
 	}// GEN-LAST:event_filterToggleActionPerformed
 
 	/**

--- a/src/main/java/uk/co/sleonard/unison/gui/generated/PajekPanel.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/PajekPanel.java
@@ -147,18 +147,20 @@ class PajekPanel extends javax.swing.JPanel implements Observer {
 		try {
 
 			this.frame = frame;
-			this.controller = UNISoNController.getInstance();
-			this.session = this.controller.helper().getHibernateSession();
+                        this.controller = UNISoNController.getInstance();
+                        this.session = this.controller.helper().getHibernateSession();
                         this.initComponents();
 
                         this.resultsMatrixTable.setEnabled(false);
                         this.getFilePreviewArea().setEditable(false);
-			this.previousRadio.setSelected(true);
-			this.refreshPajekMatrixTable();
-		}
-		catch (final UNISoNException e) {
-			this.controller.getGui().showAlert("Error: " + e.getMessage());
-		}
+                        this.previousRadio.setSelected(true);
+                        this.refreshPajekMatrixTable();
+                }
+                catch (final UNISoNException e) {
+                        if (this.controller.getGui() != null) {
+                                this.controller.getGui().showAlert("Error: " + e.getMessage());
+                        }
+                }
 
 	}
 
@@ -208,7 +210,9 @@ class PajekPanel extends javax.swing.JPanel implements Observer {
                 }
                 catch (final UNISoNException e) {
                         LOG.error("Error exporting CSV", e);
-                        this.controller.getGui().showAlert("Error: " + e.getMessage());
+                        if (this.controller.getGui() != null) {
+                                this.controller.getGui().showAlert("Error: " + e.getMessage());
+                        }
                 }
         }// GEN-LAST:event_csvButtonActionPerformed
 

--- a/src/main/java/uk/co/sleonard/unison/input/FullDownloadWorker.java
+++ b/src/main/java/uk/co/sleonard/unison/input/FullDownloadWorker.java
@@ -166,11 +166,13 @@ public class FullDownloadWorker extends SwingWorker {
 		catch (@SuppressWarnings("unused") final InterruptedException e) {
 			return "Interrupted";
 		}
-		catch (final UNISoNException e) {
-			this.controller.getGui().showAlert("Error in download:" + e);
-			e.printStackTrace();
-			return "FAIL";
-		}
+                catch (final UNISoNException e) {
+                        if (this.controller.getGui() != null) {
+                                this.controller.getGui().showAlert("Error in download:" + e);
+                        }
+                        e.printStackTrace();
+                        return "FAIL";
+                }
 		return "Completed";
 	}
 


### PR DESCRIPTION
## Summary
- Initialize UNISoNGUI within `UNISoNController`'s constructor to ensure it exists before database setup and guard alert calls if the GUI is absent.
- Add null-checked calls to `showAlert` across worker and GUI classes to prevent `NullPointerException` when no GUI is available.

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 could not be resolved – Network is unreachable)*
- `mvn -q -Djacoco.skip=true test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 could not be resolved – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f92f4dd6083278fbfdb232f762af1