### PR TITLE
Use default session when retrieving messages

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/datahandling/UNISoNDatabase.java
+++ b/src/main/java/uk/co/sleonard/unison/datahandling/UNISoNDatabase.java
@@ -47,9 +47,10 @@ public class UNISoNDatabase extends Observable {
         public Set<Message> getMessages(final Topic topic, final Session session1) {
                 final String query = "from  Message  where topic_id = " + topic.getId();
                 final HashSet<Message> returnVal = new HashSet<>();
+                final Session effective = (session1 != null) ? session1 : this.session;
                 List<Message> results = null;
                 try {
-                        results = this.helper.runQuery(query, session1, Message.class);
+                        results = this.helper.runQuery(query, effective, Message.class);
                 }
                 catch (final Exception e) {
                         log.warn("Failed to run query {}", query, e);


### PR DESCRIPTION
## Summary
- Ensure getMessages uses a non-null session by falling back to the instance's session when none provided

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f975f54f08327b9967b6a2bad9ac4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/256)
<!-- Reviewable:end -->
