### PR TITLE
Include fullName in NewsGroup equality

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/datahandling/DAO/NewsGroup.java
+++ b/src/main/java/uk/co/sleonard/unison/datahandling/DAO/NewsGroup.java
@@ -105,12 +105,13 @@ private String fullName;
                         return false;
                 }
                 final NewsGroup other = (NewsGroup) obj;
-                return this.id == other.id && Objects.equals(this.name, other.name);
+                return this.id == other.id && Objects.equals(this.name, other.name)
+                                && Objects.equals(this.fullName, other.fullName);
         }
 
         @Override
         public int hashCode() {
-                return Objects.hash(this.id, this.name);
+                return Objects.hash(this.id, this.name, this.fullName);
         }
 
         @Override


### PR DESCRIPTION
## Summary
- consider `fullName` in `NewsGroup.equals`
- include `fullName` when computing `NewsGroup.hashCode`

## Testing
- `mvn -q -Dtest=uk.co.sleonard.unison.gui.generated.MessageStoreViewerTest test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.12 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_689f9760ebdc832787c1375e26d76c77