### PR TITLE
Ensure Message mapping uses correct property case

### DIFF
--- a/src/main/resources/dao/Message.hbm.xml
+++ b/src/main/resources/dao/Message.hbm.xml
@@ -11,14 +11,14 @@
 			<meta attribute="scope-set">protected</meta>
 			<generator class="native" />
 		</id>
-		<property name="DateCreated" type="date" not-null="true"
-			column="DateCreated" />
+                <property name="dateCreated" type="date" not-null="true"
+                        column="DateCreated" />
 
-		<property name="UsenetMessageID" type="string" not-null="true"
-			column="UsenetMessageID" />
+                <property name="usenetMessageID" type="string" not-null="true"
+                        column="UsenetMessageID" />
 
-		<property name="Subject" type="string" not-null="true"
-			column="subject" />
+                <property name="subject" type="string" not-null="true"
+                        column="subject" />
 		<many-to-one name="poster" column="USENETUSER_ID"
 			class="uk.co.sleonard.unison.datahandling.DAO.UsenetUser"
 			lazy="false" not-null="false" />
@@ -31,16 +31,16 @@
 				class="uk.co.sleonard.unison.datahandling.DAO.NewsGroup"
 				column="NEWSGROUP_ID" />
 		</set>
-		<property name="referencedMessages" type="string" not-null="false"
-			column="referencedMessages" />
-		<property name="MessageBody" type="binary" not-null="false"
-			column="MessageBody" />
+                <property name="referencedMessages" type="string" not-null="false"
+                        column="referencedMessages" />
+                <property name="messageBody" type="binary" not-null="false"
+                        column="MessageBody" />
 
 	</class>
 	<query
 		name="uk.co.sleonard.unison.datahandling.DAO.Message.findByKey">
-		<![CDATA[ from uk.co.sleonard.unison.datahandling.DAO.Message as t
-	          where t.UsenetMessageID = :key
-	          ]]>
+                <![CDATA[ from uk.co.sleonard.unison.datahandling.DAO.Message as t
+                  where t.usenetMessageID = :key
+                  ]]>
 	</query>
 </hibernate-mapping>


### PR DESCRIPTION
## Summary
- Fix casing of `dateCreated`, `usenetMessageID`, `subject`, and `messageBody` properties in `Message.hbm.xml`
- Update query to reference `usenetMessageID`

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f976a497c8327993103bc5afc04da