### PR TITLE
Align Message property names with fields

### DIFF
--- a/src/main/resources/dao/Message.hbm.xml
+++ b/src/main/resources/dao/Message.hbm.xml
@@ -11,13 +11,13 @@
 			<meta attribute="scope-set">protected</meta>
 			<generator class="native" />
 		</id>
-		<property name="DateCreated" type="date" not-null="true"
+		<property name="dateCreated" type="date" not-null="true"
 			column="DateCreated" />
 
-		<property name="UsenetMessageID" type="string" not-null="true"
+		<property name="usenetMessageID" type="string" not-null="true"
 			column="UsenetMessageID" />
 
-		<property name="Subject" type="string" not-null="true"
+		<property name="subject" type="string" not-null="true"
 			column="subject" />
 		<many-to-one name="poster" column="USENETUSER_ID"
 			class="uk.co.sleonard.unison.datahandling.DAO.UsenetUser"
@@ -33,14 +33,14 @@
 		</set>
 		<property name="referencedMessages" type="string" not-null="false"
 			column="referencedMessages" />
-		<property name="MessageBody" type="binary" not-null="false"
+		<property name="messageBody" type="binary" not-null="false"
 			column="MessageBody" />
 
 	</class>
 	<query
 		name="uk.co.sleonard.unison.datahandling.DAO.Message.findByKey">
 		<![CDATA[ from uk.co.sleonard.unison.datahandling.DAO.Message as t
-	          where t.UsenetMessageID = :key
+	          where t.usenetMessageID = :key
 	          ]]>
 	</query>
 </hibernate-mapping>


### PR DESCRIPTION
## Summary
- rename message mapping property names to camelCase
- adjust query to use updated property name

## Testing
- `mvn -q -Dtest=HibernateHelperRunQueryTest test` *(fails: Could not resolve org.jacoco:jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_689f976660cc8327bac6487e7658f75b

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/259)
<!-- Reviewable:end -->
