### PR TITLE
Validate host before reconnecting in NewsClientImpl

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/input/NewsClientImpl.java
+++ b/src/main/java/uk/co/sleonard/unison/input/NewsClientImpl.java
@@ -237,6 +237,9 @@ public class NewsClientImpl implements NewsClient {
         public void reconnect() throws UNISoNException {
                 // If it should be connected but has timed out
                 if (!this.isConnected()) {
+                        if (this.host == null) {
+                                throw new UNISoNException("No host specified");
+                        }
                         try {
                                 this.connect(this.host);
                         }


### PR DESCRIPTION
## Summary
- Ensure `NewsClientImpl.reconnect` throws `UNISoNException` when no host is specified
- Keep existing exception wrapping for reconnect failures

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f976460b083279b4ff8673dba4e60