### PR TITLE
Ensure clean state before seeding test data

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperRunQueryTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperRunQueryTest.java
@@ -28,6 +28,13 @@ public class HibernateHelperRunQueryTest {
         this.helper = new HibernateHelper(null);
         this.session = this.helper.getHibernateSession();
 
+        // Ensure a clean database state before seeding
+        this.session.beginTransaction();
+        this.session.createQuery("delete from Message").executeUpdate();
+        this.session.createQuery("delete from Topic").executeUpdate();
+        this.session.createQuery("delete from UsenetUser").executeUpdate();
+        this.session.getTransaction().commit();
+
         // Seed the in-memory database with a single message
         this.session.beginTransaction();
         UsenetUser poster = new UsenetUser("poster", "poster@example.com", "127.0.0.1", null, null);


### PR DESCRIPTION
## Summary
- Ensure each test starts with an empty database by clearing Message, Topic, and UsenetUser tables
- Seed a single message in a fresh transaction for HibernateHelperRunQueryTest

## Testing
- `mvn -q test -Dtest=HibernateHelperRunQueryTest` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f9b89f0dc8327af2f2410414271fb

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/261)
<!-- Reviewable:end -->
