### PR TITLE
Connect to dummy host before reconnect in NewsClientTest

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/input/NewsClientTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/NewsClientTest.java
@@ -139,10 +139,11 @@ public class NewsClientTest {
 		this.client.connectToNewsGroup("host", "group");
 	}
 
-	@Test
-	public final void testReconnect() throws UNISoNException {
-		this.client.reconnect();
-	}
+        @Test
+        public final void testReconnect() throws UNISoNException {
+                this.client.connect("host");
+                this.client.reconnect();
+        }
 
 	@Test(expected = UNISoNException.class)
 	public final void testReconnectException()


### PR DESCRIPTION
## Summary
- Connect to a dummy host before invoking `reconnect` in `NewsClientTest#testReconnect`

## Testing
- `mvn test -Dtest=NewsClientTest#testReconnect` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689f9b851208832791a6a2611b95850e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/262)
<!-- Reviewable:end -->
