### PR TITLE
Allow nullable Session in UNISoNDatabaseTest

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/datahandling/UNISoNDatabaseTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/UNISoNDatabaseTest.java
@@ -58,8 +58,8 @@ public class UNISoNDatabaseTest {
 		        new UsenetUser("poster", "poster@email.com", "127.0.0.1", null, null),
 		        new Topic("topic", null), null, null, messageBody);
 		messages.add(msg);
-                Mockito.when(this.helper2.runQuery(ArgumentMatchers.anyString(), ArgumentMatchers.any(Session.class),
-                        ArgumentMatchers.any(Class.class))).thenReturn(messages);
+               Mockito.when(this.helper2.runQuery(ArgumentMatchers.anyString(), ArgumentMatchers.nullable(Session.class),
+                       ArgumentMatchers.any(Class.class))).thenReturn(messages);
                 final Set<Message> result = this.database.getMessages(topic, this.session2);
                 Assert.assertEquals(1, result.size());
                 Assert.assertTrue(result.contains(msg));


### PR DESCRIPTION
## Summary
- Use Mockito's `nullable(Session.class)` in UNISoNDatabaseTest so the query stub accepts null sessions.

## Testing
- `mvn -q test -Dtest=UNISoNDatabaseTest` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f9b865ef48327873121f3b13384ef

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/263)
<!-- Reviewable:end -->
