### PR TITLE
Use explicit timestamp in logback pattern

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{ABSOLUTE} %-5level %logger{36}:%line -%msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36}:%line -%msg%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
## Summary
- switch logback console appender to HH:mm:ss.SSS timestamp format

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:pom:0.8.12 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fa49211a0832784a429f4374c0f23

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/264)
<!-- Reviewable:end -->
