### PR TITLE
Remove hardcoded session factory name to avoid JNDI lookup

### DIFF
--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -3,7 +3,7 @@
 		"-//Hibernate/Hibernate Configuration DTD 3.0//EN"
 		"http://hibernate.sourceforge.net/hibernate-configuration-3.0.dtd">
 <hibernate-configuration>
-	<session-factory name="CodeGen">
+        <session-factory>
 		<property name="hibernate.connection.driver_class">
 			org.hsqldb.jdbcDriver
 		</property>


### PR DESCRIPTION
## Summary
- Remove unused JNDI name from Hibernate session-factory configuration to prevent unexpected JndiException messages.

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fa48ca86c83279d677a744670ec1e