### PR TITLE
Use explicit date format in logback

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{ABSOLUTE} %-5level %logger{36}:%line -%msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36}:%line -%msg%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
## Summary
- specify logback timestamp pattern using HH:mm:ss.SSS instead of deprecated ABSOLUTE pattern

## Testing
- `mvn -q test` *(fails: Could not resolve org.jacoco:jacoco-maven-plugin:0.8.12 - Network is unreachable)*
- `java -Djava.awt.headless=true -jar deploy/unison.jar` *(fails: java.awt.HeadlessException; no `Unknown pattern letter` warnings observed)*

------
https://chatgpt.com/codex/tasks/task_e_689fa4742ae0832799d05d55a6c8cae1