### PR TITLE
chore: update Hibernate DTD URLs

### DIFF
--- a/src/main/resources/dao/IpAddress.hbm.xml
+++ b/src/main/resources/dao/IpAddress.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE hibernate-mapping PUBLIC
 	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-	"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping package="uk.co.sleonard.unison.datahandling.DAO">
         <class name="IpAddress" table="IPADDRESS">

--- a/src/main/resources/dao/Location.hbm.xml
+++ b/src/main/resources/dao/Location.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE hibernate-mapping PUBLIC
 	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-	"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 	<hibernate-mapping package="uk.co.sleonard.unison.datahandling.DAO">
 	<class name="Location" table="LOCATION">
 		<meta attribute="class-description">

--- a/src/main/resources/dao/Message.hbm.xml
+++ b/src/main/resources/dao/Message.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE hibernate-mapping PUBLIC
 	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-	"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping package="uk.co.sleonard.unison.datahandling.DAO">
 	<class name="Message" table="MESSAGE">
 		<meta attribute="class-description">Represents a message</meta>

--- a/src/main/resources/dao/NewsGroup.hbm.xml
+++ b/src/main/resources/dao/NewsGroup.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE hibernate-mapping PUBLIC
 	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-	"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping package="uk.co.sleonard.unison.datahandling.DAO">
 	<class name="NewsGroup" table="NEWSGROUP">
 		<meta attribute="class-description">

--- a/src/main/resources/dao/Topic.hbm.xml
+++ b/src/main/resources/dao/Topic.hbm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE hibernate-mapping PUBLIC
 	"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
-	"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+	"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
 <hibernate-mapping package="uk.co.sleonard.unison.datahandling.DAO">
 	<class name="Topic" table="TOPIC">
 		<meta attribute="class-description">

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE hibernate-configuration PUBLIC
 		"-//Hibernate/Hibernate Configuration DTD 3.0//EN"
-		"http://hibernate.sourceforge.net/hibernate-configuration-3.0.dtd">
+		"http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
 <hibernate-configuration>
 	<session-factory name="CodeGen">
 		<property name="hibernate.connection.driver_class">


### PR DESCRIPTION
## Summary
- use new www.hibernate.org DTD URLs in Hibernate configuration and mappings

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_689fa48dbfa08327be873ca14b462987