### PR TITLE
Remove session factory name to avoid JNDI lookup

### DIFF
--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -3,7 +3,7 @@
 		"-//Hibernate/Hibernate Configuration DTD 3.0//EN"
 		"http://hibernate.sourceforge.net/hibernate-configuration-3.0.dtd">
 <hibernate-configuration>
-	<session-factory name="CodeGen">
+	<session-factory>
 		<property name="hibernate.connection.driver_class">
 			org.hsqldb.jdbcDriver
 		</property>


### PR DESCRIPTION
## Summary
- Drop `name="CodeGen"` attribute from Hibernate `session-factory` to stop unnecessary JNDI lookup

## Testing
- `mvn test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved)*
- `mvn -DskipTests exec:java -Dexec.mainClass=uk.co.sleonard.unison.gui.generated.DownloadNewsPanel -Djava.awt.headless=true` *(fails: No plugin found for prefix 'exec')*


------
https://chatgpt.com/codex/tasks/task_e_689fa47004208327839a58eabecd9471