### PR TITLE
Add UnisonMain launcher and update build metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ UNISoN is a Java-based NNTP client that can analyse messages to save to a Pajek-
 
 Run via [Java web start](http://unison.leonarduk.com/downloads/jnlp/launch.jnlp) - this is self-signed so you need to allow it
 
+To run from source use the `uk.co.sleonard.unison.UnisonMain` class. The legacy `DownloadNewsPanel.main` remains for testing.
+
 Just Go To *Startmenu >>Java >>Configure Java >> Security >> Edit site list >> Add >> "http://unison.leonarduk.com/" >> OK
 
 

--- a/deploy/unison.jnlp
+++ b/deploy/unison.jnlp
@@ -10,7 +10,7 @@
         <!-- Application Resources -->
             <jar href="unison.jar" main="true" />
     </resources>
-    <application-desc main-class="uk.co.sleonard.unison.gui.generated.DownloadNewsPanel">
+    <application-desc main-class="uk.co.sleonard.unison.UnisonMain">
         <!-- Application Arguments -->
     </application-desc>
     <security><all-permissions/></security>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
                     </descriptorRefs>
                     <archive>
                         <manifest>
-                            <mainClass>uk.co.sleonard.unison.gui.generated.DownloadNewsPanel
+                            <mainClass>uk.co.sleonard.unison.UnisonMain
                             </mainClass>
                         </manifest>
                     </archive>
@@ -84,7 +84,7 @@
                     <archive>
                         <manifest>
                             <addClasspath>true</addClasspath>
-                            <mainClass>uk.co.sleonard.unison.gui.generated.DownloadNewsPanel
+                            <mainClass>uk.co.sleonard.unison.UnisonMain
                             </mainClass>
                         </manifest>
                     </archive>
@@ -481,7 +481,7 @@
 
                                 <!-- used to automatically identify the jar containing the main class. -->
                                 <!-- this is perhaps going to change -->
-                                <mainClass>uk.co.sleonard.unison.gui.generated.DownloadNewsPanel
+                                <mainClass>uk.co.sleonard.unison.UnisonMain
                                 </mainClass>
                             </jnlp>
 

--- a/src/main/java/uk/co/sleonard/unison/UnisonMain.java
+++ b/src/main/java/uk/co/sleonard/unison/UnisonMain.java
@@ -1,0 +1,22 @@
+package uk.co.sleonard.unison;
+
+import javax.swing.SwingUtilities;
+import uk.co.sleonard.unison.UNISoNException;
+
+import uk.co.sleonard.unison.gui.generated.UNISoNTabbedFrame;
+
+/**
+ * Application entry point for the Unison UI.
+ */
+public class UnisonMain {
+	public static void main(final String[] args) {
+		SwingUtilities.invokeLater(() -> {
+			try {
+				final UNISoNTabbedFrame frame = new UNISoNTabbedFrame();
+				frame.setVisible(true);
+			} catch (final UNISoNException e) {
+				e.printStackTrace();
+			}
+		});
+	}
+}

--- a/src/main/resources/unison.jnlp
+++ b/src/main/resources/unison.jnlp
@@ -10,7 +10,7 @@
         <!-- Application Resources -->
             <jar href="unison.jar" main="true" />
     </resources>
-    <application-desc main-class="uk.co.sleonard.unison.gui.generated.DownloadNewsPanel">
+    <application-desc main-class="uk.co.sleonard.unison.UnisonMain">
         <!-- Application Arguments -->
     </application-desc>
     <security><all-permissions/></security>


### PR DESCRIPTION
## Summary
- add `UnisonMain` as the central Swing entry point
- point build plugins and JNLP files at `UnisonMain`
- document `UnisonMain` as the default launcher

## Testing
- `mvn -q test` *(fails: Could not transfer org.jacoco:jacoco-maven-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fafa996dc83279593fba7a475fda0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/272)
<!-- Reviewable:end -->
