### PR TITLE
Make input logging level configurable in logback

### DIFF
--- a/deploy/logback.xml
+++ b/deploy/logback.xml
@@ -7,6 +7,10 @@
 
   <logger name="org.hibernate" level="WARN"/>
 
+  <!-- Adjust the verbosity for input classes via UNISON_INPUT_LOG_LEVEL property -->
+  <!-- e.g. run with -DUNISON_INPUT_LOG_LEVEL=INFO to reduce output -->
+  <logger name="uk.co.sleonard.unison.input" level="${UNISON_INPUT_LOG_LEVEL:-DEBUG}"/>
+
   <root level="INFO">
     <appender-ref ref="CONSOLE" />
   </root>


### PR DESCRIPTION
## Summary
- add logger for `uk.co.sleonard.unison.input` at configurable level
- document property `UNISON_INPUT_LOG_LEVEL` to toggle verbosity without code changes

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_689fb7e332588327a5c0064e2ea185bc