### PR TITLE
Add test for DataHibernatorPoolImpl stopAllDownloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
             <version>${powermock.version}</version>

--- a/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
@@ -1,0 +1,28 @@
+/**
+ * DataHibernatorPoolImplTest
+ */
+package uk.co.sleonard.unison.input;
+
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * Tests for {@link DataHibernatorPoolImpl}.
+ */
+public class DataHibernatorPoolImplTest {
+
+    /**
+     * Ensure that stopAllDownloads calls DataHibernatorWorker.stopDownload.
+     */
+    @Test
+    public void testStopAllDownloadsInvokesWorker() {
+        try (MockedStatic<DataHibernatorWorker> worker = Mockito.mockStatic(DataHibernatorWorker.class)) {
+            DataHibernatorPoolImpl pool = new DataHibernatorPoolImpl();
+
+            pool.stopAllDownloads();
+
+            worker.verify(DataHibernatorWorker::stopDownload, Mockito.times(1));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DataHibernatorPoolImplTest verifying stopAllDownloads triggers DataHibernatorWorker.stopDownload once using Mockito static mock

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a024f9f1d8832786675355d541c033

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/278)
<!-- Reviewable:end -->
