### PR TITLE
Add tests for SwingWorker

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/input/SwingWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/SwingWorkerTest.java
@@ -1,0 +1,77 @@
+package uk.co.sleonard.unison.input;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link SwingWorker}.
+ */
+public class SwingWorkerTest {
+
+    private static class TestSwingWorker extends SwingWorker {
+        private final CountDownLatch constructLatch;
+        private final CountDownLatch finishedLatch;
+        volatile boolean constructCalled = false;
+        volatile boolean finishedCalled = false;
+
+        TestSwingWorker(CountDownLatch constructLatch, CountDownLatch finishedLatch) {
+            super("TestSwingWorker");
+            this.constructLatch = constructLatch;
+            this.finishedLatch = finishedLatch;
+        }
+
+        @Override
+        public Object construct() {
+            constructCalled = true;
+            constructLatch.countDown();
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+            return null;
+        }
+
+        @Override
+        public void finished() {
+            finishedCalled = true;
+            finishedLatch.countDown();
+        }
+
+        Thread getThread() throws Exception {
+            Field field = SwingWorker.class.getDeclaredField("threadVar");
+            field.setAccessible(true);
+            SwingWorker.ThreadVar tv = (SwingWorker.ThreadVar) field.get(this);
+            return tv.get();
+        }
+    }
+
+    @Test
+    public void testFinishedRunsOnCompletion() throws Exception {
+        CountDownLatch constructLatch = new CountDownLatch(1);
+        CountDownLatch finishedLatch = new CountDownLatch(1);
+        TestSwingWorker worker = new TestSwingWorker(constructLatch, finishedLatch);
+        worker.start();
+        assertTrue("Construct never started", constructLatch.await(1, TimeUnit.SECONDS));
+        assertTrue("Finished did not execute",
+                finishedLatch.await(2, TimeUnit.SECONDS) && worker.finishedCalled);
+    }
+
+    @Test
+    public void testInterruptClearsThread() throws Exception {
+        CountDownLatch constructLatch = new CountDownLatch(1);
+        CountDownLatch finishedLatch = new CountDownLatch(1);
+        TestSwingWorker worker = new TestSwingWorker(constructLatch, finishedLatch);
+        worker.start();
+        assertTrue("construct never started", constructLatch.await(1, TimeUnit.SECONDS));
+        worker.interrupt();
+        assertNull("Thread reference not cleared after interrupt", worker.getThread());
+        finishedLatch.await(1, TimeUnit.SECONDS);
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `TestSwingWorker` subclass to track construct and finished execution
- add unit tests verifying finished execution and thread clearing on interrupt

## Testing
- `mvn -q -Djacoco.skip=true -Dtest=SwingWorkerTest test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a024ed68c48327a4952a9fa3bbd59e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/283)
<!-- Reviewable:end -->
