### PR TITLE
Add Mockito inline dependency for static mock tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
             <version>${powermock.version}</version>


### PR DESCRIPTION
## Summary
- add mockito-inline test dependency to support mocking static methods

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.12 or one of its dependencies could not be resolved: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.12 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a029802de48327b75fbbb2cdd49b09