### PR TITLE
Handle null input in comma list conversion

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/utils/StringUtils.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/StringUtils.java
@@ -85,15 +85,19 @@ public class StringUtils {
 	 *            the comma separated string
 	 * @return the list
 	 */
-	static List<String> convertCommasToList(final String commaSeparatedString) {
-		final Vector<String> words = new Vector<>();
+        static List<String> convertCommasToList(final String commaSeparatedString) {
+                final Vector<String> words = new Vector<>();
 
-		final StringTokenizer tok = new StringTokenizer(commaSeparatedString, ",");
-		while (tok.hasMoreTokens()) {
-			words.add(tok.nextToken());
-		}
-		return words;
-	}
+                if (commaSeparatedString == null || commaSeparatedString.isEmpty()) {
+                        return words;
+                }
+
+                final StringTokenizer tok = new StringTokenizer(commaSeparatedString, ",");
+                while (tok.hasMoreTokens()) {
+                        words.add(tok.nextToken());
+                }
+                return words;
+        }
 
 	/**
 	 * Convert date to string.

--- a/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
+++ b/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
@@ -49,11 +49,20 @@ public class StringUtilsTest {
 	/**
 	 * Test convert commas to list.
 	 */
-	@Test
-	public void testConvertCommasToList() {
-		List<String> list = StringUtils.convertCommasToList("comma, separated, string");
-		assertEquals(3, list.size());
-	}
+        @Test
+        public void testConvertCommasToList() {
+                List<String> list = StringUtils.convertCommasToList("comma, separated, string");
+                assertEquals(3, list.size());
+        }
+
+       /**
+        * Test convert commas to list if null.
+        */
+       @Test
+       public void testConvertCommasToListIfNull() {
+               List<String> list = StringUtils.convertCommasToList(null);
+               assertTrue(list.isEmpty());
+       }
 
 	/**
 	 * Test compress decompress.


### PR DESCRIPTION
## Summary
- Handle null or empty strings when splitting comma-separated values
- Add regression test covering null input for comma list conversion

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a034a32ad483278a9f6522520e6b6e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/290)
<!-- Reviewable:end -->
