### PR TITLE
Use try-with-resources in saveToFile

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/output/PajekNetworkFile.java
+++ b/src/main/java/uk/co/sleonard/unison/output/PajekNetworkFile.java
@@ -203,18 +203,11 @@ public class PajekNetworkFile {
         if (!filenameInput.endsWith(this.suffix)) {
             this.filename += this.suffix;
         }
-        FileOutputStream out; // declare a file output object
-        PrintStream p; // declare a print stream object
-
         // Create a new file output stream
-        try {
-            out = new FileOutputStream(this.filename);
-
+        try (FileOutputStream out = new FileOutputStream(this.filename);
+                PrintStream p = new PrintStream(out)) {
             // Connect print stream to the output stream
-            p = new PrintStream(out);
             this.writeData(p);
-
-            p.close();
         } catch (final FileNotFoundException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
## Summary
- wrap FileOutputStream and PrintStream in try-with-resources for saveToFile
- rely on automatic resource management

## Testing
- `mvn org.apache.maven.plugins:maven-checkstyle-plugin:2.9.1:check -DskipTests` *(fails: Could not transfer artifact due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a04690acc083279e1d0375582fefb7

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/291)
<!-- Reviewable:end -->
