### PR TITLE
Refactor PajekNetworkFile logging and resource management

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/output/PajekNetworkFile.java
+++ b/src/main/java/uk/co/sleonard/unison/output/PajekNetworkFile.java
@@ -6,6 +6,7 @@
  */
 package uk.co.sleonard.unison.output;
 
+import lombok.extern.slf4j.Slf4j;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.gui.GraphPreviewPanel;
 
@@ -23,6 +24,7 @@ import java.util.Vector;
  * @author Stephen <github@leonarduk.com>
  * @since v1.0.0
  */
+@Slf4j
 public class PajekNetworkFile {
 
     /**
@@ -203,22 +205,14 @@ public class PajekNetworkFile {
         if (!filenameInput.endsWith(this.suffix)) {
             this.filename += this.suffix;
         }
-        FileOutputStream out; // declare a file output object
-        PrintStream p; // declare a print stream object
-
         // Create a new file output stream
-        try {
-            out = new FileOutputStream(this.filename);
-
-            // Connect print stream to the output stream
-            p = new PrintStream(out);
+        try (FileOutputStream out = new FileOutputStream(this.filename);
+             PrintStream p = new PrintStream(out)) {
             this.writeData(p);
-
-            p.close();
         } catch (final FileNotFoundException e) {
             e.printStackTrace();
         }
-        System.out.println("Saved to " + this.filename);
+        log.info("Saved to {}", this.filename);
     }
 
     /**


### PR DESCRIPTION
## Summary
- use Lombok's @Slf4j in PajekNetworkFile for logging
- replace System.out with log.info
- streamline saveToFile using try-with-resources for stream management

## Testing
- `mvn -q test` *(fails: Could not transfer artifact maven-resources-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a04695ad7c8327b2f2cf2d425f76d2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/292)
<!-- Reviewable:end -->
