### PR TITLE
Fix newsgroup selection and file save handling

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/NewsGroupFilter.java
+++ b/src/main/java/uk/co/sleonard/unison/NewsGroupFilter.java
@@ -175,7 +175,9 @@ public class NewsGroupFilter {
     public void setSelectedNewsgroup(final String groupName) {
         if (!StringUtils.isEmpty(groupName)) {
             NewsGroup group = this.helper.getNewsgroupByFullName(groupName, this.session);
-            this.setSelectedNewsgroup(group.getName());
+            this.selectedNewsgroup = group;
+        } else {
+            this.selectedNewsgroup = null;
         }
     }
 }

--- a/src/main/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewer.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewer.java
@@ -349,8 +349,10 @@ class MessageStoreViewer extends javax.swing.JPanel implements Observer, UNISoNL
     private void crosspostComboBoxActionPerformed(final java.awt.event.ActionEvent evt) {// GEN-FIRST:event_crosspostComboBoxActionPerformed
         final UNISoNController controller = UNISoNController.getInstance();
         final NewsGroup selectedGroup = (NewsGroup) this.crosspostComboBox.getSelectedItem();
-        controller.getFilter().setSelectedNewsgroup(selectedGroup.getName());
-        this.refreshTopicHierarchy();
+        if (selectedGroup != null) {
+            controller.getFilter().setSelectedNewsgroup(selectedGroup.getName());
+            this.refreshTopicHierarchy();
+        }
         // controller.showAlert("You chose " + selectedGroup);
     }// GEN-LAST:event_crosspostComboBoxActionPerformed
 
@@ -429,14 +431,13 @@ class MessageStoreViewer extends javax.swing.JPanel implements Observer, UNISoNL
         final TreePath tp = evt.getPath();
         final TreeNode root = (TreeNode) tp.getLastPathComponent();
 
-        // as root is not a newsgroup
-        if (root.getUserObject() instanceof NewsGroup) {
-            NewsGroup newsGroup = (NewsGroup) root.getUserObject();
+        final Object userObject = root.getUserObject();
+        if (userObject instanceof NewsGroup newsGroup) {
             UNISoNController.getInstance().getFilter()
                     .setSelectedNewsgroup(newsGroup.getName());
-        } else {
+        } else if (userObject instanceof String groupName) {
             UNISoNController.getInstance().getFilter()
-                    .setSelectedNewsgroup((String) root.getUserObject());
+                    .setSelectedNewsgroup(groupName);
         }
 
         this.notifySelectedNewsGroupObservers();

--- a/src/main/java/uk/co/sleonard/unison/output/PajekNetworkFile.java
+++ b/src/main/java/uk/co/sleonard/unison/output/PajekNetworkFile.java
@@ -208,12 +208,13 @@ public class PajekNetworkFile {
         }
         // Create a new file output stream
         try (FileOutputStream out = new FileOutputStream(this.filename);
-            // Connect print stream to the output stream
-            PrintStream p = new PrintStream(out)) {
+             // Connect print stream to the output stream
+             PrintStream p = new PrintStream(out)) {
+            this.writeData(p);
+            log.info("Saved to {}", this.filename);
         } catch (final IOException e) {
-            e.printStackTrace();
+            log.error("Failed to save Pajek network file", e);
         }
-        log.info("Saved to {}", this.filename);
     }
 
     /**

--- a/src/test/java/uk/co/sleonard/unison/NewsGroupFilterTest.java
+++ b/src/test/java/uk/co/sleonard/unison/NewsGroupFilterTest.java
@@ -141,18 +141,18 @@ public class NewsGroupFilterTest {
 
     }
 
-//    @Test
-//    public final void testSelectedNewsgroup() {
-//        this.newsGroupFilter.setFiltered(false);
-//        Assert.assertNull(this.newsGroupFilter.getSelectedNewsgroup());
-//        final NewsGroup expected = new NewsGroup();
-//        final String fullName = "Test";
-//        expected.setFullName(fullName);
-//        Mockito.when(this.helper.getNewsgroupByFullName(fullName, this.session))
-//                .thenReturn(expected);
-//        this.newsGroupFilter.setSelectedNewsgroup(expected.getFullName());
-//        Assert.assertEquals(expected, this.newsGroupFilter.getSelectedNewsgroup());
-//    }
+    @Test
+    public final void testSelectedNewsgroup() {
+        this.newsGroupFilter.setFiltered(false);
+        Assert.assertNull(this.newsGroupFilter.getSelectedNewsgroup());
+        final NewsGroup expected = new NewsGroup();
+        final String fullName = "Test";
+        expected.setFullName(fullName);
+        Mockito.when(this.helper.getNewsgroupByFullName(fullName, this.session))
+                .thenReturn(expected);
+        this.newsGroupFilter.setSelectedNewsgroup(expected.getFullName());
+        Assert.assertEquals(expected, this.newsGroupFilter.getSelectedNewsgroup());
+    }
 
     @Test
     public final void testSelectedNewsgroupFiltered() {


### PR DESCRIPTION
## Summary
- prevent `NewsGroupFilter#setSelectedNewsgroup` from infinite recursion
- guard against null newsgroup selections in `MessageStoreViewer`
- write actual data and log errors in `PajekNetworkFile#saveToFile`
- re-enable unit test for selected newsgroup

## Testing
- `mvn -q test` *(fails: could not resolve Maven plugin due to network issue)*

------
https://chatgpt.com/codex/tasks/task_e_68a04c2bef58832797aee6efd87ad0bd