### PR TITLE
Improve PajekNetworkFile resource handling and validation

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/output/PajekNetworkFile.java
+++ b/src/main/java/uk/co/sleonard/unison/output/PajekNetworkFile.java
@@ -197,20 +197,23 @@ public class PajekNetworkFile {
     }
 
     /**
-     * Save to file.
+     * Save graph data to a Pajek network file.
      *
-     * @param filename the filename
+     * @param filenameInput the base filename to save to
+     * @throws IllegalArgumentException if {@code filenameInput} is null or empty
      */
     public void saveToFile(final String filenameInput) {
+        if (filenameInput == null || filenameInput.trim().isEmpty()) {
+            throw new IllegalArgumentException("Filename must not be null or empty");
+        }
         this.filename = filenameInput;
         if (!filenameInput.endsWith(this.suffix)) {
             this.filename += this.suffix;
         }
-        // Create a new file output stream
+        // Use try-with-resources to ensure the stream is always closed
         try (FileOutputStream out = new FileOutputStream(this.filename);
-             // Connect print stream to the output stream
-             PrintStream p = new PrintStream(out)) {
-            this.writeData(p);
+             PrintStream printStream = new PrintStream(out)) {
+            this.writeData(printStream);
             log.info("Saved to {}", this.filename);
         } catch (final IOException e) {
             log.error("Failed to save Pajek network file", e);

--- a/src/test/java/uk/co/sleonard/unison/output/PajekNetworkFileTest.java
+++ b/src/test/java/uk/co/sleonard/unison/output/PajekNetworkFileTest.java
@@ -114,6 +114,14 @@ public class PajekNetworkFileTest {
     }
 
     /**
+     * saveToFile should reject a null or empty filename.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testSaveToFileWithInvalidFilename() {
+        this.file.saveToFile(" ");
+    }
+
+    /**
      * test writeData.
      */
     @Test


### PR DESCRIPTION
## Summary
- Validate filename input before saving network files
- Rename and document PrintStream usage within try-with-resources
- Add unit test ensuring invalid filenames are rejected

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a04852f22c83279a92dc25918784e6

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/299)
<!-- Reviewable:end -->
