### PR TITLE
Refactor StringUtils to use List and split

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/utils/StringUtils.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/StringUtils.java
@@ -23,6 +23,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -71,15 +72,15 @@ public class StringUtils {
      * @return the list
      */
     static List<String> convertCommasToList(final String commaSeparatedString) {
-        final Vector<String> words = new Vector<>();
+        final List<String> words = new ArrayList<>();
 
         if (commaSeparatedString == null || commaSeparatedString.isEmpty()) {
             return words;
         }
 
-        final StringTokenizer tok = new StringTokenizer(commaSeparatedString, ",");
-        while (tok.hasMoreTokens()) {
-            words.add(tok.nextToken());
+        final String[] tokens = commaSeparatedString.split(",");
+        for (final String token : tokens) {
+            words.add(token);
         }
         return words;
     }
@@ -111,17 +112,21 @@ public class StringUtils {
      *
      * @param field      the field
      * @param delimiters the delimiters
-     * @return the vector
+     * @return the list
      */
-    public static Vector<String> convertStringToList(final String field, final String delimiters) {
-        final Vector<String> list = new Vector<>();
+    public static List<String> convertStringToList(final String field, final String delimiters) {
+        final List<String> list = new ArrayList<>();
         if (null == field) {
             return list;
         }
-        final StringTokenizer fields = new StringTokenizer(field, delimiters);
+        if (delimiters == null || delimiters.isEmpty()) {
+            list.add(field);
+            return list;
+        }
+        final String regex = "[" + Pattern.quote(delimiters) + "]";
+        final String[] fields = field.split(regex);
 
-        while (fields.hasMoreElements()) {
-            final String nextToken = fields.nextToken();
+        for (final String nextToken : fields) {
             list.add(nextToken);
             // System.out.println("Adding " + nextToken);
         }

--- a/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
+++ b/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
@@ -10,7 +10,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
-import java.util.Vector;
 
 import static org.junit.Assert.*;
 
@@ -27,7 +26,7 @@ public class StringUtilsTest {
      */
     @Test
     public void testConvertStringToList() {
-        Vector<String> list = StringUtils.convertStringToList("string-to-list-test", "-");
+        List<String> list = StringUtils.convertStringToList("string-to-list-test", "-");
         assertEquals(4, list.size());
     }
 
@@ -36,9 +35,8 @@ public class StringUtilsTest {
      */
     @Test
     public void testConvertStringToListIfNull() {
-        final Vector<String> listEmpty = new Vector<String>();
-        Vector<String> list = StringUtils.convertStringToList(null, "");
-        assertEquals(listEmpty, list);
+        List<String> list = StringUtils.convertStringToList(null, "");
+        assertTrue(list.isEmpty());
     }
 
     /**


### PR DESCRIPTION
## Summary
- Replace Vector and StringTokenizer with List/ArrayList and String.split in StringUtils
- Update return types and tests to use generics

## Testing
- `mvn -q test` *(failed: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d5a6c2d08327862ea1b4c3cc81a7