### PR TITLE
Use Lombok for equality and update tests

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/datahandling/DAO/Message.java
+++ b/src/main/java/uk/co/sleonard/unison/datahandling/DAO/Message.java
@@ -8,10 +8,9 @@ package uk.co.sleonard.unison.datahandling.DAO;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -25,7 +24,7 @@ import java.util.Set;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Slf4j
+@EqualsAndHashCode
 public class Message implements java.io.Serializable {
     private static final long serialVersionUID = -4828381724935020136L;
     private Date dateCreated;
@@ -49,84 +48,6 @@ public class Message implements java.io.Serializable {
         this.newsgroups = newsgroups;
         this.referencedMessages = referencedMessages;
         this.messageBody = messageBody;
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            log.debug("thatOne is null");
-            return false;
-        }
-        if (this.getClass() != obj.getClass()) {
-            log.debug("thatOne is a " + obj.getClass().getName());
-            return false;
-        }
-        final Message other = (Message) obj;
-        if (this.dateCreated == null) {
-            if (other.dateCreated != null) {
-                log.debug("thatOne doesn't have null dateCreated");
-                return false;
-            }
-        } else if (!this.dateCreated.equals(other.dateCreated)) {
-            log.debug("thatOne has a different dateCreated");
-            return false;
-        }
-        if (this.id != other.id) {
-            log.debug("thatOne has different Id");
-
-            return false;
-        }
-        if (!Arrays.equals(this.messageBody, other.messageBody)) {
-            log.debug("thatOne has a different body");
-            return false;
-        }
-        if (this.newsgroups == null) {
-            if (other.newsgroups != null) {
-                return false;
-            }
-        } else if (!this.newsgroups.equals(other.newsgroups)) {
-            return false;
-        }
-        if (this.poster == null) {
-            if (other.poster != null) {
-                return false;
-            }
-        } else if (!this.poster.equals(other.poster)) {
-            log.debug("thatOne has different poster" + this.poster + ":" + other.poster);
-            return false;
-        }
-        if (this.referencedMessages == null) {
-            if (other.referencedMessages != null) {
-                return false;
-            }
-        } else if (!this.referencedMessages.equals(other.referencedMessages)) {
-            return false;
-        }
-        if (this.subject == null) {
-            if (other.subject != null) {
-                return false;
-            }
-        } else if (!this.subject.equals(other.subject)) {
-            return false;
-        }
-        if (this.topic == null) {
-            if (other.topic != null) {
-                return false;
-            }
-        } else if (!this.topic.equals(other.topic)) {
-            return false;
-        }
-        if (this.usenetMessageID == null) {
-            if (other.usenetMessageID != null) {
-                return false;
-            }
-        } else if (!this.usenetMessageID.equals(other.usenetMessageID)) {
-            return false;
-        }
-        return true;
     }
 
     @Override

--- a/src/main/java/uk/co/sleonard/unison/output/Relationship.java
+++ b/src/main/java/uk/co/sleonard/unison/output/Relationship.java
@@ -6,12 +6,15 @@
  */
 package uk.co.sleonard.unison.output;
 
+import lombok.EqualsAndHashCode;
+
 /**
  * The Class Relationship.
  *
  * @author Stephen <github@leonarduk.com>
  * @since v1.0.0
  */
+@EqualsAndHashCode
 public class Relationship {
 
     /**
@@ -45,30 +48,6 @@ public class Relationship {
         this.target = target;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (this.getClass() != obj.getClass()) {
-            return false;
-        }
-        final Relationship other = (Relationship) obj;
-        if (this.owner != other.owner) {
-            return false;
-        }
-        if (this.target != other.target) {
-            return false;
-        }
-        if (this.value != other.value) {
-            return false;
-        }
-        return true;
-    }
-
     /**
      * Gets the owner.
      *
@@ -94,16 +73,6 @@ public class Relationship {
      */
     public int getValue() {
         return this.value;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = (prime * result) + this.owner;
-        result = (prime * result) + this.target;
-        result = (prime * result) + this.value;
-        return result;
     }
 
     /**

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/MessageTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/MessageTest.java
@@ -7,9 +7,7 @@
 package uk.co.sleonard.unison.datahandling.DAO;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.util.*;
 
@@ -58,59 +56,26 @@ public class MessageTest {
     }
 
     @Test
-    @Ignore
-    public void testEquals() throws Exception {
+    public void testEqualsAndHashCode() {
         final Date dateCreated = new Date();
         final String usenetMessageID = "ID1";
         final String subject = "Bad day";
-        final UsenetUser poster = new UsenetUser("Steve", "test@email.com", "127.0.0.1", "male",
-                new Location("city", "Country", "CountryCode", false, new ArrayList<>(),
-                        new ArrayList<>()));
+        final UsenetUser poster = new UsenetUser();
+        final Topic topic = new Topic();
         final Set<NewsGroup> newsgroups = new HashSet<>();
-        final Set<Topic> topics = new HashSet<>();
-        final Set<Message> messages = new HashSet<>();
-        newsgroups.add(new NewsGroup("alt.rubbish", null, topics, messages, 2, 2, 1, 2,
-                "alt.rubbish", true));
-        final Topic topic = new Topic("rubbish", newsgroups);
-        topics.add(topic);
-        final String referencedMessages = null;
-        final byte[] messageBody = "This is bad".getBytes();
-        final Message thisOne = new Message(dateCreated, usenetMessageID, subject, poster, topic,
+        final String referencedMessages = "ref";
+        final byte[] messageBody = {1, 2, 3};
+        final Message m1 = new Message(dateCreated, usenetMessageID, subject, poster, topic,
                 newsgroups, referencedMessages, messageBody);
-        final Message sameOne = new Message(dateCreated, usenetMessageID, subject, poster, topic,
-                newsgroups, referencedMessages, messageBody);
+        final Message m2 = new Message(dateCreated, usenetMessageID, subject, poster, topic,
+                new HashSet<>(newsgroups), referencedMessages,
+                Arrays.copyOf(messageBody, messageBody.length));
 
-        Assert.assertEquals(thisOne, sameOne);
-        Assert.assertEquals(thisOne, thisOne);
-        Assert.assertTrue(thisOne.equals(sameOne));
+        Assert.assertEquals(m1, m2);
+        Assert.assertEquals(m1.hashCode(), m2.hashCode());
 
-        final Calendar instance = Calendar.getInstance();
-        instance.add(Calendar.YEAR, 1);
-        final Message thatone = new Message(instance.getTime(), usenetMessageID, subject, poster,
-                topic, newsgroups, referencedMessages, messageBody);
-        Assert.assertFalse(thisOne + ":" + thatone, thisOne.equals(thatone));
-
-        Assert.assertFalse(thisOne.equals(new Message(dateCreated, usenetMessageID + "2", subject,
-                poster, topic, newsgroups, referencedMessages, messageBody)));
-        Assert.assertFalse(thisOne.equals(new Message(dateCreated, usenetMessageID, subject + "2",
-                poster, topic, newsgroups, referencedMessages, messageBody)));
-//		Assert.assertFalse(thisOne.equals(new Message(dateCreated, usenetMessageID, subject,
-//		        new UsenetUser(poster).setGender("female"), topic, newsgroups, referencedMessages,
-//		        messageBody)));
-//		Assert.assertFalse(thisOne.equals(new Message(dateCreated, usenetMessageID, subject, poster,
-//		        new Topic(topic).setSubject("new subject"), newsgroups, referencedMessages,
-//		        messageBody)));
-        Assert.assertFalse(thisOne.equals(new Message(dateCreated, usenetMessageID, subject, poster,
-                topic, newsgroups, "new@message.com", messageBody)));
-        Assert.assertFalse(thisOne.equals(new Message(dateCreated, usenetMessageID, subject, poster,
-                topic, newsgroups, referencedMessages, "another".getBytes())));
-        final Set<NewsGroup> newsgroups2 = new HashSet<>(newsgroups);
-        newsgroups2.add(Mockito.mock(NewsGroup.class));
-        Assert.assertFalse(thisOne.equals(new Message(dateCreated, usenetMessageID, subject, poster,
-                topic, newsgroups2, referencedMessages, messageBody)));
-        Assert.assertFalse(thisOne.equals(null));
-        Assert.assertFalse(thisOne.equals("eggs"));
-
+        m2.setSubject("Different");
+        Assert.assertNotEquals(m1, m2);
     }
 
     /**

--- a/src/test/java/uk/co/sleonard/unison/output/RelationshipTest.java
+++ b/src/test/java/uk/co/sleonard/unison/output/RelationshipTest.java
@@ -32,8 +32,13 @@ public class RelationshipTest {
      */
     @Test
     public void testEquals() {
-        Assert.assertEquals(new Relationship(10, 10), new Relationship(10, 10));
-        Assert.assertFalse(new Relationship(10, 10).equals(new Object()));
+        final Relationship r1 = new Relationship(10, 10);
+        final Relationship r2 = new Relationship(10, 10);
+        final Relationship r3 = new Relationship(10, 11);
+
+        Assert.assertEquals(r1, r2);
+        Assert.assertEquals(r2, r1);
+        Assert.assertNotEquals(r1, r3);
     }
 
     /**
@@ -71,10 +76,11 @@ public class RelationshipTest {
      */
     @Test
     public void testHashCode() {
-        final Relationship test = new Relationship(10, 20);
-        Assert.assertEquals(40022, test.hashCode());
-        test.incrementValue();
-        Assert.assertEquals(40023, test.hashCode());
+        final Relationship r1 = new Relationship(10, 20);
+        final Relationship r2 = new Relationship(10, 20);
+        Assert.assertEquals(r1.hashCode(), r2.hashCode());
+        r2.incrementValue();
+        Assert.assertNotEquals(r1.hashCode(), r2.hashCode());
     }
 
     /**


### PR DESCRIPTION
## Summary
- Replace manual `equals`/`hashCode` in `Message` and `Relationship` with Lombok's `@EqualsAndHashCode`
- Remove debug logging from message equality
- Add unit tests covering equality and hash code contracts

## Testing
- `mvn -q test` *(fails: PluginResolutionException due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d5ab23488327b7956cb7573b75de