### PR TITLE
Refactor NewsGroupReader to accept injected NewsClient

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/UNISoNController.java
+++ b/src/main/java/uk/co/sleonard/unison/UNISoNController.java
@@ -130,7 +130,8 @@ public class UNISoNController {
             throw e;
         }
 
-        this.nntpReader = new NewsGroupReader(this);
+        this.client = new NewsClientImpl();
+        this.nntpReader = new NewsGroupReader(this.client);
     }
 
     public void cancel() {

--- a/src/main/java/uk/co/sleonard/unison/input/NewsGroupReader.java
+++ b/src/main/java/uk/co/sleonard/unison/input/NewsGroupReader.java
@@ -41,10 +41,10 @@ public class NewsGroupReader {
     /**
      * Instantiates a new news group reader.
      *
-     * @param controller the controller
+     * @param client the {@link NewsClient} to use
      */
-    public NewsGroupReader(final UNISoNController controller) {
-        this.client = new NewsClientImpl();
+    public NewsGroupReader(final NewsClient client) {
+        this.client = client;
     }
 
 

--- a/src/test/java/uk/co/sleonard/unison/input/NewsGroupReaderTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/NewsGroupReaderTest.java
@@ -10,7 +10,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import uk.co.sleonard.unison.UNISoNController;
 
 /**
  * The Class NewsGroupReaderTest.
@@ -31,9 +30,8 @@ public class NewsGroupReaderTest {
      *             the exception
      */
     @Before
-    public void setUp() throws Exception {
-        final UNISoNController uniController = Mockito.mock(UNISoNController.class);
-        this.newsGroup = new NewsGroupReader(uniController);
+    public void setUp() {
+        this.newsGroup = new NewsGroupReader(new NewsClientImpl());
     }
 
     /**
@@ -72,9 +70,20 @@ public class NewsGroupReaderTest {
     @Test
     public void testGetNumberOfMessages() {
         final NewsClient mockNewsClient = Mockito.mock(NewsClient.class);
-        this.newsGroup.client = mockNewsClient;
         Mockito.when(mockNewsClient.getMessageCount()).thenReturn(10);
+        this.newsGroup.setClient(mockNewsClient);
         Assert.assertEquals(10, this.newsGroup.getNumberOfMessages());
+    }
+
+    /**
+     * Ensure the supplied NewsClient is used by the reader.
+     */
+    @Test
+    public void testSuppliedNewsClientIsUsed() {
+        final NewsClient mockClient = Mockito.mock(NewsClient.class);
+        final NewsGroupReader reader = new NewsGroupReader(mockClient);
+        reader.getNumberOfMessages();
+        Mockito.verify(mockClient).getMessageCount();
     }
 
     /**


### PR DESCRIPTION
## Summary
- Refactored `NewsGroupReader` to accept a `NewsClient` instance instead of constructing its own client
- Updated `UNISoNController` to create a `NewsClientImpl` and pass it to `NewsGroupReader`
- Added unit tests verifying `NewsGroupReader` uses a provided `NewsClient`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d5ac1f888327a34d44984fc6f6e1