### PR TITLE
Add tests for downloader and hibernator pool

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
@@ -1,0 +1,30 @@
+package uk.co.sleonard.unison.input;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * Tests for {@link DataHibernatorPoolImpl}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(DataHibernatorWorker.class)
+public class DataHibernatorPoolImplTest {
+
+    /**
+     * Verifies stopAllDownloads delegates to DataHibernatorWorker.stopDownload().
+     */
+    @Test
+    public void testStopAllDownloadsDelegates() {
+        PowerMockito.mockStatic(DataHibernatorWorker.class);
+
+        DataHibernatorPool pool = new DataHibernatorPoolImpl();
+        pool.stopAllDownloads();
+
+        PowerMockito.verifyStatic(DataHibernatorWorker.class, Mockito.times(1));
+        DataHibernatorWorker.stopDownload();
+    }
+}

--- a/src/test/java/uk/co/sleonard/unison/utils/DownloaderImplTest.java
+++ b/src/test/java/uk/co/sleonard/unison/utils/DownloaderImplTest.java
@@ -1,0 +1,50 @@
+package uk.co.sleonard.unison.utils;
+
+import org.hibernate.Session;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import uk.co.sleonard.unison.UNISoNException;
+import uk.co.sleonard.unison.datahandling.HibernateHelper;
+import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest.DownloadMode;
+import uk.co.sleonard.unison.input.FullDownloadWorker;
+import uk.co.sleonard.unison.input.NewsArticle;
+import uk.co.sleonard.unison.input.NewsClient;
+import uk.co.sleonard.unison.input.NewsGroupReader;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Tests for {@link DownloaderImpl}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(FullDownloadWorker.class)
+public class DownloaderImplTest {
+
+    /**
+     * Ensures that addDownloadRequest delegates to FullDownloadWorker with correct parameters.
+     */
+    @Test
+    public void testAddDownloadRequestDelegatesCorrectly() throws UNISoNException {
+        String nntpHost = "host";
+        LinkedBlockingQueue<NewsArticle> queue = new LinkedBlockingQueue<>();
+        NewsClient newsClient = Mockito.mock(NewsClient.class);
+        NewsGroupReader reader = Mockito.mock(NewsGroupReader.class);
+        HibernateHelper helper = Mockito.mock(HibernateHelper.class);
+        Session session = Mockito.mock(Session.class);
+
+        PowerMockito.mockStatic(FullDownloadWorker.class);
+
+        DownloaderImpl downloader = new DownloaderImpl(nntpHost, queue, newsClient, reader, helper, session);
+        String usenetId = "<123>";
+        DownloadMode mode = DownloadMode.ALL;
+
+        downloader.addDownloadRequest(usenetId, mode);
+
+        PowerMockito.verifyStatic(FullDownloadWorker.class, Mockito.times(1));
+        FullDownloadWorker.addDownloadRequest(usenetId, mode, nntpHost, queue, newsClient, reader, helper, session);
+    }
+}


### PR DESCRIPTION
## Summary
- test that DownloaderImpl delegates addDownloadRequest to FullDownloadWorker with all parameters
- test that DataHibernatorPoolImpl.stopAllDownloads forwards to DataHibernatorWorker.stopDownload

## Testing
- `mvn -q -Dtest=DownloaderImplTest,DataHibernatorPoolImplTest test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d5a59934832783fbcc3fbc2ddc01

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/306)
<!-- Reviewable:end -->
