### PR TITLE
Ensure concurrent visibility of worker state

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/input/HeaderDownloadWorker.java
+++ b/src/main/java/uk/co/sleonard/unison/input/HeaderDownloadWorker.java
@@ -43,8 +43,8 @@ public class HeaderDownloadWorker extends SwingWorker {
 
 
     @Getter
-    private boolean downloading = false;
-    private boolean running = true;
+    private volatile boolean downloading = false;
+    private volatile boolean running = true;
     private final ReentrantLock pauseLock = new ReentrantLock();
     private final Condition notPaused = pauseLock.newCondition();
     private int logTally = 0;

--- a/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerInvokeTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerInvokeTest.java
@@ -1,0 +1,30 @@
+package uk.co.sleonard.unison.input;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import uk.co.sleonard.unison.utils.Downloader;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Tests that setting downloading to true triggers storeArticleInfo.
+ */
+public class HeaderDownloadWorkerInvokeTest {
+
+    @Test
+    public void testDownloadingTriggersStoreArticleInfo() throws Exception {
+        LinkedBlockingQueue<NewsArticle> queue = new LinkedBlockingQueue<>();
+        Downloader downloader = Mockito.mock(Downloader.class);
+        HeaderDownloadWorker worker = Mockito.spy(new HeaderDownloadWorker(queue, downloader));
+
+        Mockito.doAnswer(invocation -> {
+            worker.fullStop();
+            return true;
+        }).when(worker).storeArticleInfo(Mockito.any());
+
+        worker.resume();
+        worker.construct();
+
+        Mockito.verify(worker, Mockito.times(1)).storeArticleInfo(Mockito.any());
+    }
+}


### PR DESCRIPTION
## Summary
- mark HeaderDownloadWorker running/downloading flags as volatile for cross-thread visibility
- add unit test verifying that enabling downloading triggers storeArticleInfo

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d7e5750c83278ff18652470648a1