### PR TITLE
Document public interface methods

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/StatusMonitor.java
+++ b/src/main/java/uk/co/sleonard/unison/StatusMonitor.java
@@ -11,8 +11,18 @@ import uk.co.sleonard.unison.datahandling.DAO.NewsGroup;
 import java.util.Set;
 
 public interface StatusMonitor {
+    /**
+     * Called when the ability to download articles changes.
+     *
+     * @param enabled {@code true} if downloading is currently permitted; {@code false} otherwise
+     */
     void downloadEnabled(final boolean enabled);
 
-    public void updateAvailableGroups(final Set<NewsGroup> availableGroups);
+    /**
+     * Informs the monitor that the set of downloadable groups has been refreshed.
+     *
+     * @param availableGroups the groups that are now available for download
+     */
+    void updateAvailableGroups(final Set<NewsGroup> availableGroups);
 
 }

--- a/src/main/java/uk/co/sleonard/unison/input/DataHibernatorPool.java
+++ b/src/main/java/uk/co/sleonard/unison/input/DataHibernatorPool.java
@@ -8,6 +8,9 @@ package uk.co.sleonard.unison.input;
 
 public interface DataHibernatorPool {
 
+    /**
+     * Requests that all active download processes terminate.
+     */
     void stopAllDownloads();
 
 }

--- a/src/main/java/uk/co/sleonard/unison/input/NewsClient.java
+++ b/src/main/java/uk/co/sleonard/unison/input/NewsClient.java
@@ -16,36 +16,131 @@ import java.util.Set;
 
 public interface NewsClient {
 
-    public void connect(final String server) throws IOException;
+    /**
+     * Connects to an NNTP server using the default port.
+     *
+     * @param server the host name of the server
+     * @throws IOException if the connection cannot be established
+     */
+    void connect(final String server) throws IOException;
 
-    public void connect(String hostname, int i) throws IOException;
+    /**
+     * Connects to an NNTP server using the supplied port.
+     *
+     * @param hostname the server host name
+     * @param port     the port to connect to
+     * @throws IOException if the connection fails
+     */
+    void connect(String hostname, int port) throws IOException;
 
-    public void connect(String server, int port, String username, String password)
+    /**
+     * Connects to an NNTP server using explicit credentials.
+     *
+     * @param server   the server host name
+     * @param port     the server port
+     * @param username the username to authenticate with
+     * @param password the password to authenticate with
+     * @throws UNISoNException if authentication or connection fails
+     */
+    void connect(String server, int port, String username, String password)
             throws UNISoNException;
 
-    public void connectToNewsGroup(String host, String newsgroup) throws Exception;
+    /**
+     * Establishes a connection to the specified newsgroup on the given host.
+     *
+     * @param host      the NNTP server host
+     * @param newsgroup the name of the newsgroup to join
+     * @throws Exception if the newsgroup cannot be selected
+     */
+    void connectToNewsGroup(String host, String newsgroup) throws Exception;
 
-    public void disconnect();
+    /**
+     * Disconnects from the currently connected server.
+     */
+    void disconnect();
 
-    public int getMessageCount();
+    /**
+     * Gets the number of messages reported by the server for the selected group.
+     *
+     * @return the message count
+     */
+    int getMessageCount();
 
-    public boolean isConnected();
+    /**
+     * Indicates whether the client is currently connected to a server.
+     *
+     * @return {@code true} if connected; {@code false} otherwise
+     */
+    boolean isConnected();
 
-    public Set<NewsGroup> listNewsGroups(String searchString, String host) throws UNISoNException;
+    /**
+     * Lists available newsgroups matching the provided search text.
+     *
+     * @param searchString optional text to filter group names
+     * @param host         the NNTP server to query
+     * @return the set of matching newsgroups
+     * @throws UNISoNException if the list cannot be retrieved
+     */
+    Set<NewsGroup> listNewsGroups(String searchString, String host) throws UNISoNException;
 
-    public int quit() throws IOException;
+    /**
+     * Issues a QUIT command to the server.
+     *
+     * @return the response code from the server
+     * @throws IOException if an I/O error occurs
+     */
+    int quit() throws IOException;
 
-    public void reconnect() throws UNISoNException;
+    /**
+     * Re-establishes a connection using previously supplied settings.
+     *
+     * @throws UNISoNException if the reconnect attempt fails
+     */
+    void reconnect() throws UNISoNException;
 
-    public Reader retrieveArticle(String usenetID) throws IOException;
+    /**
+     * Retrieves a full article by its message identifier.
+     *
+     * @param usenetID the message ID of the article
+     * @return a reader over the article content
+     * @throws IOException if the article cannot be retrieved
+     */
+    Reader retrieveArticle(String usenetID) throws IOException;
 
-    public Reader retrieveArticleHeader(final String articleId) throws IOException;
+    /**
+     * Retrieves only the headers for a particular article.
+     *
+     * @param articleId the message ID of the article
+     * @return a reader over the article headers
+     * @throws IOException if the headers cannot be retrieved
+     */
+    Reader retrieveArticleHeader(final String articleId) throws IOException;
 
-    public BufferedReader retrieveArticleInfo(final long lowArticleNumber,
-                                              final long highArticleNumber) throws IOException;
+    /**
+     * Retrieves article metadata between two message numbers.
+     *
+     * @param lowArticleNumber  the first article number to fetch
+     * @param highArticleNumber the last article number to fetch
+     * @return a reader over the range information
+     * @throws IOException if the information cannot be retrieved
+     */
+    BufferedReader retrieveArticleInfo(final long lowArticleNumber,
+                                       final long highArticleNumber) throws IOException;
 
-    public boolean selectNewsgroup(String newsgroup1) throws IOException;
+    /**
+     * Selects the given newsgroup as the current group.
+     *
+     * @param newsgroup the newsgroup to select
+     * @return {@code true} if selection was successful
+     * @throws IOException if the group cannot be selected
+     */
+    boolean selectNewsgroup(String newsgroup) throws IOException;
 
-    public void setMessageCount(int messageCount);
+    /**
+     * Sets the message count for the current group.
+     *
+     * @param messageCount the number of messages reported by the server
+     */
+    void setMessageCount(int messageCount);
 
 }

--- a/src/main/java/uk/co/sleonard/unison/utils/Downloader.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/Downloader.java
@@ -10,6 +10,14 @@ import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest.DownloadMode;
 
 public interface Downloader {
+    /**
+     * Queue a request to download a Usenet message.
+     *
+     * @param usenetID the unique message identifier to fetch
+     * @param mode determines how much of the message to retrieve; one of
+     *             {@link DownloadMode#BASIC}, {@link DownloadMode#HEADERS} or {@link DownloadMode#ALL}
+     * @throws UNISoNException if the request cannot be queued or the mode is unsupported
+     */
     void addDownloadRequest(final String usenetID, final DownloadMode mode) throws UNISoNException;
 
 }


### PR DESCRIPTION
## Summary
- document StatusMonitor callbacks and parameters
- clarify Downloader addDownloadRequest modes and errors
- add missing Javadoc across public interfaces

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ec183d508327957cb8032a908990