### PR TITLE
Use Lombok for message count

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/input/NewsClientImpl.java
+++ b/src/main/java/uk/co/sleonard/unison/input/NewsClientImpl.java
@@ -6,6 +6,8 @@
  */
 package uk.co.sleonard.unison.input;
 
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.net.nntp.NNTPClient;
 import org.apache.commons.net.nntp.NewsgroupInfo;
@@ -38,6 +40,8 @@ public class NewsClientImpl implements NewsClient {
     /**
      * The message count.
      */
+    @Getter(onMethod_ = @Override)
+    @Setter(onMethod_ = @Override)
     private int messageCount;
     private final NNTPClient client;
 
@@ -141,16 +145,6 @@ public class NewsClientImpl implements NewsClient {
         } catch (final Exception e) {
             e.printStackTrace();
         }
-    }
-
-    /**
-     * Gets the message count.
-     *
-     * @return the message count
-     */
-    @Override
-    public int getMessageCount() {
-        return this.messageCount;
     }
 
     @Override
@@ -259,13 +253,4 @@ public class NewsClientImpl implements NewsClient {
         return this.client.selectNewsgroup(newsgroup);
     }
 
-    /**
-     * Sets the message count.
-     *
-     * @param messageCount the new message count
-     */
-    @Override
-    public void setMessageCount(final int messageCount) {
-        this.messageCount = messageCount;
-    }
 }


### PR DESCRIPTION
## Summary
- replace explicit messageCount accessor methods with Lombok-generated versions

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ec126fc083279e428e9fd4d5d099