### PR TITLE
Refactor Observer pattern to PropertyChangeSupport

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/DataChangeListener.java
+++ b/src/main/java/uk/co/sleonard/unison/DataChangeListener.java
@@ -1,0 +1,23 @@
+package uk.co.sleonard.unison;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+/**
+ * Listener interface used throughout the application to listen for
+ * changes in data.
+ */
+@FunctionalInterface
+public interface DataChangeListener extends PropertyChangeListener {
+    /**
+     * Called when the underlying data has changed.
+     *
+     * @param evt description of the change
+     */
+    void dataChanged(PropertyChangeEvent evt);
+
+    @Override
+    default void propertyChange(PropertyChangeEvent evt) {
+        dataChanged(evt);
+    }
+}

--- a/src/main/java/uk/co/sleonard/unison/datahandling/UNISoNDatabase.java
+++ b/src/main/java/uk/co/sleonard/unison/datahandling/UNISoNDatabase.java
@@ -14,17 +14,21 @@ import uk.co.sleonard.unison.datahandling.DAO.NewsGroup;
 import uk.co.sleonard.unison.datahandling.DAO.Topic;
 import uk.co.sleonard.unison.datahandling.DAO.UsenetUser;
 
+import java.beans.PropertyChangeSupport;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Observable;
 import java.util.Set;
 
+import uk.co.sleonard.unison.DataChangeListener;
+
 @Slf4j
-public class UNISoNDatabase extends Observable {
+public class UNISoNDatabase {
     private final Session session;
     private final NewsGroupFilter filter;
     private final HibernateHelper helper;
     private final DataQuery dataQuery;
+
+    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
     public UNISoNDatabase(final NewsGroupFilter filter2, final Session session2,
                           final HibernateHelper helper2, final DataQuery dataQuery) {
@@ -71,15 +75,29 @@ public class UNISoNDatabase extends Observable {
         return returnVal;
     }
 
-    /*
-     * (non-Javadoc)
+    /**
+     * Register a listener to be notified when the database data changes.
      *
-     * @see java.util.Observable#notifyObservers()
+     * @param listener the listener to register
      */
-    @Override
-    public void notifyObservers() {
-        this.setChanged();
-        super.notifyObservers();
+    public void addDataChangeListener(final DataChangeListener listener) {
+        this.pcs.addPropertyChangeListener(listener);
+    }
+
+    /**
+     * Remove a previously registered listener.
+     *
+     * @param listener the listener to remove
+     */
+    public void removeDataChangeListener(final DataChangeListener listener) {
+        this.pcs.removePropertyChangeListener(listener);
+    }
+
+    /**
+     * Notify all registered listeners that the data has changed.
+     */
+    public void notifyListeners() {
+        this.pcs.firePropertyChange("database", null, null);
     }
 
     /**
@@ -149,7 +167,7 @@ public class UNISoNDatabase extends Observable {
                 }
             }
         }
-        this.notifyObservers();
+        this.notifyListeners();
     }
 
     @Override

--- a/src/main/java/uk/co/sleonard/unison/gui/generated/DownloadNewsPanel.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/DownloadNewsPanel.java
@@ -13,8 +13,8 @@ import uk.co.sleonard.unison.datahandling.DAO.NewsGroup;
 import uk.co.sleonard.unison.input.HeaderDownloadWorker;
 import uk.co.sleonard.unison.utils.StringUtils;
 
-import java.util.Observable;
-import java.util.Observer;
+import java.beans.PropertyChangeEvent;
+import uk.co.sleonard.unison.DataChangeListener;
 import java.util.Set;
 
 /**
@@ -26,7 +26,7 @@ import java.util.Set;
 @Slf4j
 @SuppressWarnings("rawtypes")
 public class DownloadNewsPanel extends javax.swing.JPanel
-        implements Observer, StatusMonitor {
+        implements DataChangeListener, StatusMonitor {
 
     /**
      * The Constant serialVersionUID.
@@ -172,7 +172,7 @@ public class DownloadNewsPanel extends javax.swing.JPanel
         this.initComponents();
 
         this.controller.setNntpHost(StringUtils.loadServerList()[0]);
-        this.controller.getHeaderDownloader().addObserver(this);
+        this.controller.getHeaderDownloader().addDataChangeListener(this);
 
         this.controller.setNntpHost(this.hostCombo.getSelectedItem().toString());
         this.downloadEnabled(false);
@@ -538,17 +538,16 @@ public class DownloadNewsPanel extends javax.swing.JPanel
     /*
      * (non-Javadoc)
      *
-     * @see java.util.Observer#update(java.util.Observable, java.lang.Object)
+     * @see uk.co.sleonard.unison.DataChangeListener#dataChanged(java.beans.PropertyChangeEvent)
      */
     @Override
-    public void update(final Observable observable, final Object arg1) {
-        if (observable instanceof HeaderDownloadWorker) {
-            final HeaderDownloadWorker headerDownloader = (HeaderDownloadWorker) observable;
+    public void dataChanged(final PropertyChangeEvent evt) {
+        final Object source = evt.getSource();
+        if (source instanceof HeaderDownloadWorker) {
+            final HeaderDownloadWorker headerDownloader = (HeaderDownloadWorker) source;
             if (!headerDownloader.isDownloading()) {
                 this.downloadEnabled(true);
             }
-            // } else if (observable instanceof UNISoNController) {
-            // UNISoNController controller = (UNISoNController) observable;
         }
     }
 

--- a/src/main/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewer.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewer.java
@@ -27,6 +27,9 @@ import java.text.SimpleDateFormat;
 import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.List;
+import java.beans.PropertyChangeEvent;
+
+import uk.co.sleonard.unison.DataChangeListener;
 
 /**
  * The Class MessageStoreViewer.
@@ -35,7 +38,7 @@ import java.util.List;
  * @since v1.0.0
  */
 @Slf4j
-class MessageStoreViewer extends javax.swing.JPanel implements Observer {
+class MessageStoreViewer extends javax.swing.JPanel implements DataChangeListener {
 
     /**
      * The Constant serialVersionUID.
@@ -1142,10 +1145,10 @@ class MessageStoreViewer extends javax.swing.JPanel implements Observer {
     /*
      * (non-Javadoc)
      *
-     * @see java.util.Observer#update(java.util.Observable, java.lang.Object)
+     * @see uk.co.sleonard.unison.DataChangeListener#dataChanged(java.beans.PropertyChangeEvent)
      */
     @Override
-    public void update(final Observable observable, final Object arg1) {
+    public void dataChanged(final PropertyChangeEvent evt) {
         this.refreshGUIData();
     }
 

--- a/src/main/java/uk/co/sleonard/unison/gui/generated/PajekPanel.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/PajekPanel.java
@@ -30,6 +30,9 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.*;
 import java.util.List;
+import java.beans.PropertyChangeEvent;
+
+import uk.co.sleonard.unison.DataChangeListener;
 
 /**
  * The Class PajekPanel.
@@ -38,7 +41,7 @@ import java.util.List;
  * @since v1.0.0
  */
 @Slf4j
-class PajekPanel extends javax.swing.JPanel implements Observer {
+class PajekPanel extends javax.swing.JPanel implements DataChangeListener {
 
     /**
      * The Constant PAJEK_NETWORK_FILE_SUFFIX.
@@ -467,7 +470,7 @@ class PajekPanel extends javax.swing.JPanel implements Observer {
      * @param evt the evt
      */
     private void previewButtonActionPerformed(final java.awt.event.ActionEvent evt) {// GEN-FIRST:event_previewButtonActionPerformed
-        UNISoNController.getInstance().getDatabase().notifyObservers();
+        UNISoNController.getInstance().getDatabase().notifyListeners();
     }// GEN-LAST:event_previewButtonActionPerformed
 
     /**
@@ -561,12 +564,11 @@ class PajekPanel extends javax.swing.JPanel implements Observer {
     /*
      * (non-Javadoc)
      *
-     * @see java.util.Observer#update(java.util.Observable, java.lang.Object)
+     * @see uk.co.sleonard.unison.DataChangeListener#dataChanged(java.beans.PropertyChangeEvent)
      */
     @Override
-    public void update(final Observable observable, final Object arg1) {
-        if (observable instanceof UNISoNDatabase) {
-            // UNISoNController controller = (UNISoNController) observable;
+    public void dataChanged(final PropertyChangeEvent evt) {
+        if (evt.getSource() instanceof UNISoNDatabase) {
             try {
                 this.refreshPajekMatrixTable();
             } catch (final UNISoNException e) {

--- a/src/main/java/uk/co/sleonard/unison/gui/generated/UNISoNTabbedFrame.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/UNISoNTabbedFrame.java
@@ -16,8 +16,8 @@ import uk.co.sleonard.unison.input.DataHibernatorPoolImpl;
 import javax.swing.*;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
-import java.util.Observable;
-import java.util.Observer;
+import java.beans.PropertyChangeEvent;
+import uk.co.sleonard.unison.DataChangeListener;
 
 /**
  * The Class UNISoNTabbedFrame.
@@ -25,7 +25,7 @@ import java.util.Observer;
  * @author Stephen <github@leonarduk.com>
  * @since v1.0.0
  */
-public class UNISoNTabbedFrame extends javax.swing.JFrame implements Observer {
+public class UNISoNTabbedFrame extends javax.swing.JFrame implements DataChangeListener {
 
     /**
      * The Constant serialVersionUID.
@@ -154,10 +154,10 @@ public class UNISoNTabbedFrame extends javax.swing.JFrame implements Observer {
         splash.setProgress(80);
 
         final UNISoNDatabase database = this.controller.getDatabase();
-        database.addObserver(this.downloadNewsPanel1);
-        database.addObserver(this.messageStoreViewer1);
-        database.addObserver(this.pajekPanel1);
-        database.addObserver(this);
+        database.addDataChangeListener(this.downloadNewsPanel1);
+        database.addDataChangeListener(this.messageStoreViewer1);
+        database.addDataChangeListener(this.pajekPanel1);
+        database.addDataChangeListener(this);
 
         this.aboutDialog = new AboutDialog(this, false);
 
@@ -348,11 +348,11 @@ public class UNISoNTabbedFrame extends javax.swing.JFrame implements Observer {
     /*
      * (non-Javadoc)
      *
-     * @see java.util.Observer#update(java.util.Observable, java.lang.Object)
+     * @see uk.co.sleonard.unison.DataChangeListener#dataChanged(java.beans.PropertyChangeEvent)
      */
     @Override
-    public void update(final Observable observable, final Object arg1) {
-        if (observable instanceof UNISoNDatabase) {
+    public void dataChanged(final PropertyChangeEvent evt) {
+        if (evt.getSource() instanceof UNISoNDatabase) {
             this.showAlert("GUI has been refreshed from the database");
         }
     }

--- a/src/main/java/uk/co/sleonard/unison/input/SwingWorker.java
+++ b/src/main/java/uk/co/sleonard/unison/input/SwingWorker.java
@@ -7,7 +7,6 @@
 package uk.co.sleonard.unison.input;
 
 import javax.swing.*;
-import java.util.Observable;
 
 /**
  * from http://java.sun.com/products/jfc/tsc/articles/threads/threads2.html
@@ -24,7 +23,7 @@ import java.util.Observable;
  * @author Stephen <github@leonarduk.com>
  * @since v1.0.0
  */
-abstract class SwingWorker extends Observable implements Runnable {
+abstract class SwingWorker implements Runnable {
     /**
      * The thread var.
      */

--- a/src/test/java/uk/co/sleonard/unison/datahandling/UNISoNDatabaseTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/UNISoNDatabaseTest.java
@@ -65,12 +65,12 @@ public class UNISoNDatabaseTest {
     }
 
     @Test
-    public final void testNotifyObservers() {
+    public final void testNotifyListeners() {
         Assert.assertEquals(0, this.i);
-        this.database.addObserver((o, arg) -> {
+        this.database.addDataChangeListener(evt -> {
             this.i++;
         });
-        this.database.notifyObservers();
+        this.database.notifyListeners();
         Assert.assertEquals(1, this.i);
     }
 

--- a/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Field;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * The Class HeaderDownloadWorker.
@@ -108,11 +109,14 @@ public class HeaderDownloadWorkerTest {
     }
 
     /**
-     * Test NotifyObservers.
+     * Test listener notification.
      */
     @Test
-    public void testNotifyObservers() {
-        this.worker.notifyObservers();
+    public void testNotifyListeners() {
+        final AtomicInteger counter = new AtomicInteger(0);
+        this.worker.addDataChangeListener(evt -> counter.incrementAndGet());
+        this.worker.notifyListeners();
+        Assert.assertEquals(1, counter.get());
     }
 
     /**


### PR DESCRIPTION
## Summary
- Introduce `DataChangeListener` functional interface for app-wide data events
- Replace `Observable`/`Observer` with `PropertyChangeSupport` in core classes
- Update GUI components and tests to use the new listener API

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ec0dd9b083278b71cbdc3bcb6d0e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/315)
<!-- Reviewable:end -->
