### PR TITLE
Add debug logs to requestDownload flow

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/UNISoNController.java
+++ b/src/main/java/uk/co/sleonard/unison/UNISoNController.java
@@ -337,17 +337,21 @@ public class UNISoNController {
                                 final NewsClient client2) {
         this.setNntpHost(host);
         log.info("Find groups matching : {} on {}", group, host);
+        log.debug("Request download: group={}, host={}, disabling download button", group, host);
         monitor.downloadEnabled(false);
 
         if (null != group) {
             try {
                 final Set<NewsGroup> availableGroups2 = this.listNewsgroups(group, host, client2);
+                log.debug("listNewsgroups returned {} groups", availableGroups2.size());
                 if ((null == availableGroups2) || (availableGroups2.size() == 0)) {
                     log.warn("No groups found for string : {} on {}.\nPerhaps another host?", group, host);
                 } else {
                     monitor.downloadEnabled(true);
                 }
+                log.debug("Updating monitor with retrieved groups");
                 monitor.updateAvailableGroups(availableGroups2);
+                log.debug("Download request flow complete; monitor enabled = {}", availableGroups2.size() > 0);
             } catch (final UNISoNException e) {
                 log.error("Problem downloading", e);
             }


### PR DESCRIPTION
## Summary
- add debug logging around download request to track button state, returned groups, monitor update, and completion

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f79ad584832782335e3b7bf8f25f

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/317)
<!-- Reviewable:end -->
