### PR TITLE
Improve initialization logging in HeaderDownloadWorker

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/input/HeaderDownloadWorker.java
+++ b/src/main/java/uk/co/sleonard/unison/input/HeaderDownloadWorker.java
@@ -234,12 +234,14 @@ public class HeaderDownloadWorker extends SwingWorker {
         this.fromDate = from;
         this.toDate = to;
 
-        log.info(" Server: " + server + " Newsgroup: " + newsgroup1);
+        log.info("Initialising: server={}, group={}, start={}, end={}, mode={}, from={}, to={}",
+                server, newsgroup1, startIndex1, endIndex1, mode1, from, to);
         try {
             reader.client.connect(server);
             reader.client.selectNewsgroup(newsgroup1);
         } catch (final Exception e) {
-            log.warn(e.getMessage(), e);
+            log.warn("Initialisation failed for group {} on {}: {}", newsgroup1, server,
+                    e.getMessage(), e);
             throw new UNISoNException("Failed to initialise downloader", e);
         }
 


### PR DESCRIPTION
## Summary
- log all initialization parameters in HeaderDownloadWorker
- include detailed warning when initialization fails

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f739fc6883278a5eb8c56acf9755