### PR TITLE
Add detailed logging around NNTP connections

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/input/NewsClientImpl.java
+++ b/src/main/java/uk/co/sleonard/unison/input/NewsClientImpl.java
@@ -169,11 +169,14 @@ public class NewsClientImpl implements NewsClient {
     @Override
     public Set<NewsGroup> listNewsGroups(final String wildcard, final String nntpserver)
             throws UNISoNException {
+        log.debug("Listing newsgroups for wildcard '{}' on '{}'", wildcard, nntpserver);
 
         final Set<NewsGroup> groupSet = new TreeSet<>();
 
         try {
+            log.debug("Connecting to NNTP server {}", nntpserver);
             this.connect(nntpserver);
+            log.debug("Connected to {}", nntpserver);
             // Attempt a simple command to keep the connection alive before listing
             try {
                 this.client.listHelp();
@@ -200,6 +203,7 @@ public class NewsClientImpl implements NewsClient {
                 }
             }
         } catch (final Exception e) {
+            log.error("Failed to list newsgroups on {}: {}", nntpserver, e.getMessage(), e);
             throw new UNISoNException("Failed to connect", e);
         }
 


### PR DESCRIPTION
## Summary
- log wildcard and server at listNewsGroups entry
- log connecting and success around NNTP connections
- log failures when listing newsgroups

## Testing
- `mvn -e test` *(fails: PluginResolutionException - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f736f9c08327ae335c122546ac1e