### PR TITLE
refactor: inject dependencies into controller

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/UNISoNController.java
+++ b/src/main/java/uk/co/sleonard/unison/UNISoNController.java
@@ -86,11 +86,15 @@ public class UNISoNController {
 
     private final DataHibernatorPool pool;
 
-    private NewsClient client;
+    private final NewsClient client;
 
     public static UNISoNController create(final JFrame frame, final DataHibernatorPool pool)
             throws UNISoNException {
-        UNISoNController.instance = new UNISoNController(frame, pool);
+        UNISoNGUI gui = (frame != null) ? new UNISoNGUI(frame) : null;
+        HibernateHelper helper = new HibernateHelper(gui);
+        LinkedBlockingQueue<NewsArticle> queue = new LinkedBlockingQueue<>();
+        NewsClient client = new NewsClientImpl();
+        UNISoNController.instance = new UNISoNController(client, helper, queue, pool, gui);
         return UNISoNController.instance;
     }
     // private static UNISoNController instance;
@@ -105,19 +109,36 @@ public class UNISoNController {
     }
 
     /**
-     * Instantiates a new UNI so n controller.
+     * Set the global instance (intended for tests).
      *
-     * @throws UNISoNException
+     * @param controller the controller to set as the singleton instance
      */
-    private UNISoNController(final JFrame frame, final DataHibernatorPool hibernatorPool)
+    public static void setInstance(final UNISoNController controller) {
+        UNISoNController.instance = controller;
+    }
+
+    /**
+     * Public constructor allowing explicit dependency injection.
+     *
+     * @param client         the NNTP client implementation
+     * @param helper         the hibernate helper
+     * @param messageQueue   queue used for downloaded articles
+     * @param hibernatorPool pool controlling download threads
+     * @param gui            optional GUI reference
+     * @throws UNISoNException if the hibernate session cannot be created
+     */
+    public UNISoNController(final NewsClient client, final HibernateHelper helper,
+                            final LinkedBlockingQueue<NewsArticle> messageQueue,
+                            final DataHibernatorPool hibernatorPool, final UNISoNGUI gui)
             throws UNISoNException {
         this.pool = hibernatorPool;
-        this.gui = (frame != null) ? new UNISoNGUI(frame) : null;
+        this.gui = gui;
+        this.messageQueue = messageQueue;
+        this.helper = helper;
+        this.client = client;
 
-        this.messageQueue = new LinkedBlockingQueue<>();
-        this.helper = new HibernateHelper(this.gui);
         try {
-            final Session hibernateSession = this.getHelper().getHibernateSession();
+            final Session hibernateSession = this.helper.getHibernateSession();
             this.setSession(hibernateSession);
             this.filter = new NewsGroupFilter(hibernateSession, this.helper);
             this.analysis = new UNISoNAnalysis(this.filter, hibernateSession, this.helper);
@@ -130,7 +151,6 @@ public class UNISoNController {
             throw e;
         }
 
-        this.client = new NewsClientImpl();
         this.nntpReader = new NewsGroupReader(this.client);
     }
 
@@ -315,7 +335,6 @@ public class UNISoNController {
         log.debug("Starting quick download of {} groups (mode={}, from={}, to={})", groups.size(),
                 mode, fromDate1, toDate1);
         final NewsGroupReader reader = this.getNntpReader();
-        this.client = reader.getClient();
         final HeaderDownloadWorker headerDownloader2 = this.getHeaderDownloader();
         final String nntpHost2 = this.getNntpHost();
 

--- a/src/main/java/uk/co/sleonard/unison/utils/DownloaderImpl.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/DownloaderImpl.java
@@ -7,7 +7,6 @@
 package uk.co.sleonard.unison.utils;
 
 import org.hibernate.Session;
-import uk.co.sleonard.unison.UNISoNController;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest.DownloadMode;
 import uk.co.sleonard.unison.datahandling.HibernateHelper;
@@ -23,14 +22,6 @@ public class DownloaderImpl implements Downloader {
     private final NewsGroupReader nntpReader;
     private final HibernateHelper helper;
     private final Session session;
-
-    public DownloaderImpl() {
-        this(UNISoNController.getInstance().getNntpHost(),
-                UNISoNController.getInstance().getQueue(), new NewsClientImpl(),
-                UNISoNController.getInstance().getNntpReader(),
-                UNISoNController.getInstance().getHelper(),
-                UNISoNController.getInstance().getSession());
-    }
 
     public DownloaderImpl(final String nntpHost, final LinkedBlockingQueue<NewsArticle> queue1,
                           final NewsClient newsClient1, final NewsGroupReader reader,

--- a/src/test/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewerTest.java
@@ -15,9 +15,9 @@ import uk.co.sleonard.unison.datahandling.HibernateHelper;
 import uk.co.sleonard.unison.gui.UNISoNGUI;
 import uk.co.sleonard.unison.utils.TreeNode;
 
-import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
+import java.lang.reflect.Field;
 
 import static org.junit.Assert.assertEquals;
 
@@ -42,9 +42,7 @@ public class MessageStoreViewerTest {
         Mockito.when(this.controller.getFilter()).thenReturn(this.filter);
         Mockito.when(this.controller.getGui()).thenReturn(gui);
 
-        final Field instance = UNISoNController.class.getDeclaredField("instance");
-        instance.setAccessible(true);
-        instance.set(null, this.controller);
+        UNISoNController.setInstance(this.controller);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- refactor `UNISoNController` to accept explicit `NewsClient`, `HibernateHelper` and `LinkedBlockingQueue` dependencies
- remove implicit singleton use from `DownloaderImpl` and tests
- add convenient `setInstance` for tests and update unit tests for constructor injection

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a4e220d48327b7f6866ae5e5d1cc