### PR TITLE
Migrate tests to JUnit 5 and drop PowerMock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>2.0.13</slf4j.version>
         <logback.version>1.5.6</logback.version>
-        <junit.version>4.13.2</junit.version>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <java.version>17</java.version>
-        <powermock.version>2.0.9</powermock.version>
         <mockito.version>5.12.0</mockito.version>
         <lombok.version>1.18.30</lombok.version>
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
@@ -148,11 +147,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
                 <configuration>
                     <includes>
                         <include>**/*Test.java</include>
                         <include>${it.includes}</include>
                     </includes>
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
             <plugin>
@@ -258,9 +259,10 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- remove mockito-inline -->
@@ -275,21 +277,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/uk/co/sleonard/unison/NewsGroupFilterTest.java
+++ b/src/test/java/uk/co/sleonard/unison/NewsGroupFilterTest.java
@@ -7,9 +7,9 @@
 package uk.co.sleonard.unison;
 
 import org.hibernate.Session;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.co.sleonard.unison.datahandling.DAO.Message;
 import uk.co.sleonard.unison.datahandling.DAO.NewsGroup;
@@ -28,7 +28,7 @@ public class NewsGroupFilterTest {
     private HibernateHelper helper;
     private Session session;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.helper = Mockito.mock(HibernateHelper.class);
         this.session = Mockito.mock(Session.class);
@@ -37,197 +37,197 @@ public class NewsGroupFilterTest {
 
     @Test
     public final void testCountriesFilter() {
-        Assert.assertEquals(0, this.newsGroupFilter.getCountriesFilter().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getCountriesFilter().size());
         final Set<String> countriesFilter = new HashSet<>();
         countriesFilter.add("UK");
         this.newsGroupFilter.setCountriesFilter(countriesFilter);
-        Assert.assertEquals(1, this.newsGroupFilter.getCountriesFilter().size());
+        Assertions.assertEquals(1, this.newsGroupFilter.getCountriesFilter().size());
         this.newsGroupFilter.clear();
-        Assert.assertEquals(0, this.newsGroupFilter.getCountriesFilter().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getCountriesFilter().size());
     }
 
     @Test
     public final void testDates() {
         final Date fromDate2 = new Date();
         final Date toDate2 = new Date();
-        Assert.assertNull(this.newsGroupFilter.getFromDate());
-        Assert.assertNull(this.newsGroupFilter.getToDate());
+        Assertions.assertNull(this.newsGroupFilter.getFromDate());
+        Assertions.assertNull(this.newsGroupFilter.getToDate());
         this.newsGroupFilter.setDates(fromDate2, toDate2);
         this.newsGroupFilter.setFromDate(fromDate2);
-        Assert.assertEquals(fromDate2, this.newsGroupFilter.getFromDate());
+        Assertions.assertEquals(fromDate2, this.newsGroupFilter.getFromDate());
 
         this.newsGroupFilter.setToDate(toDate2);
-        Assert.assertEquals(toDate2, this.newsGroupFilter.getToDate());
+        Assertions.assertEquals(toDate2, this.newsGroupFilter.getToDate());
 
     }
 
     @Test
     public final void testFiltered() {
-        Assert.assertFalse(this.newsGroupFilter.isFiltered());
+        Assertions.assertFalse(this.newsGroupFilter.isFiltered());
         this.newsGroupFilter.setFiltered(true);
-        Assert.assertTrue(this.newsGroupFilter.isFiltered());
+        Assertions.assertTrue(this.newsGroupFilter.isFiltered());
     }
 
     @Test
     public final void testMessage() {
-        Assert.assertNull(this.newsGroupFilter.getMessage());
+        Assertions.assertNull(this.newsGroupFilter.getMessage());
         final Message expected = new Message();
         expected.setSubject("test");
         this.newsGroupFilter.setMessage(expected);
-        Assert.assertEquals(expected, this.newsGroupFilter.getMessage());
+        Assertions.assertEquals(expected, this.newsGroupFilter.getMessage());
     }
 
     @Test
     public final void testMessagesFilter() {
-        Assert.assertEquals(0, this.newsGroupFilter.getMessagesFilter().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getMessagesFilter().size());
         final Vector<Message> filter = new Vector<>();
         filter.add(Mockito.mock(Message.class));
         this.newsGroupFilter.setMessagesFilter(filter);
-        Assert.assertEquals(1, this.newsGroupFilter.getMessagesFilter().size());
+        Assertions.assertEquals(1, this.newsGroupFilter.getMessagesFilter().size());
         this.newsGroupFilter.clear();
-        Assert.assertEquals(0, this.newsGroupFilter.getMessagesFilter().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getMessagesFilter().size());
     }
 
     @Test
     public final void testNewsgroupFilter() {
-        Assert.assertEquals(0, this.newsGroupFilter.getNewsgroupFilter().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getNewsgroupFilter().size());
         final Set<NewsGroup> filter = new HashSet<>();
         filter.add(Mockito.mock(NewsGroup.class));
         this.newsGroupFilter.setNewsgroupFilter(filter);
-        Assert.assertEquals(1, this.newsGroupFilter.getNewsgroupFilter().size());
+        Assertions.assertEquals(1, this.newsGroupFilter.getNewsgroupFilter().size());
         this.newsGroupFilter.clear();
-        Assert.assertEquals(0, this.newsGroupFilter.getNewsgroupFilter().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getNewsgroupFilter().size());
     }
 
     @Test
     public final void testSelectedCountries() {
         this.newsGroupFilter.setFiltered(true);
-        Assert.assertEquals(0, this.newsGroupFilter.getSelectedCountries().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getSelectedCountries().size());
         final Set<String> topsNewsgroups = new HashSet<>();
         topsNewsgroups.add("UK");
         this.newsGroupFilter.setSelectedCountries(topsNewsgroups);
-        Assert.assertEquals(1, this.newsGroupFilter.getSelectedCountries().size());
+        Assertions.assertEquals(1, this.newsGroupFilter.getSelectedCountries().size());
         this.newsGroupFilter.clear();
-        Assert.assertEquals(0, this.newsGroupFilter.getSelectedCountries().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getSelectedCountries().size());
 
     }
 
     @Test
     public final void testSelectedMessage() {
         this.newsGroupFilter.setFiltered(false);
-        Assert.assertNull(this.newsGroupFilter.getSelectedMessage());
+        Assertions.assertNull(this.newsGroupFilter.getSelectedMessage());
         final Message expected = new Message();
         expected.setSubject("test");
         this.newsGroupFilter.setMessage(expected);
-        Assert.assertEquals(expected, this.newsGroupFilter.getSelectedMessage());
+        Assertions.assertEquals(expected, this.newsGroupFilter.getSelectedMessage());
     }
 
     @Test
     public final void testSelectedMessageFiltered() {
         this.newsGroupFilter.setFiltered(true);
-        Assert.assertNull(this.newsGroupFilter.getSelectedMessage());
+        Assertions.assertNull(this.newsGroupFilter.getSelectedMessage());
     }
 
     @Test
     public final void testSelectedMessages() {
         this.newsGroupFilter.setFiltered(true);
-        Assert.assertEquals(0, this.newsGroupFilter.getSelectedMessages().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getSelectedMessages().size());
         final Vector<Message> topsNewsgroups = new Vector<>();
         topsNewsgroups.add(Mockito.mock(Message.class));
         this.newsGroupFilter.setSelectedMessages(topsNewsgroups);
-        Assert.assertEquals(1, this.newsGroupFilter.getSelectedMessages().size());
+        Assertions.assertEquals(1, this.newsGroupFilter.getSelectedMessages().size());
         this.newsGroupFilter.clear();
-        Assert.assertEquals(0, this.newsGroupFilter.getSelectedMessages().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getSelectedMessages().size());
 
     }
 
 //    @Test
 //    public final void testSelectedNewsgroup() {
 //        this.newsGroupFilter.setFiltered(false);
-//        Assert.assertNull(this.newsGroupFilter.getSelectedNewsgroup());
+//        Assertions.assertNull(this.newsGroupFilter.getSelectedNewsgroup());
 //        final NewsGroup expected = new NewsGroup();
 //        final String fullName = "Test";
 //        expected.setFullName(fullName);
 //        Mockito.when(this.helper.getNewsgroupByFullName(fullName, this.session))
 //                .thenReturn(expected);
 //        this.newsGroupFilter.setSelectedNewsgroup(expected.getFullName());
-//        Assert.assertEquals(expected, this.newsGroupFilter.getSelectedNewsgroup());
+//        Assertions.assertEquals(expected, this.newsGroupFilter.getSelectedNewsgroup());
 //    }
 
     @Test
     public final void testSelectedNewsgroupFiltered() {
         this.newsGroupFilter.setFiltered(true);
-        Assert.assertNull(this.newsGroupFilter.getSelectedNewsgroup());
+        Assertions.assertNull(this.newsGroupFilter.getSelectedNewsgroup());
     }
 
     @Test
     public final void testSelectedNewsgroups() {
         this.newsGroupFilter.setFiltered(true);
-        Assert.assertEquals(0, this.newsGroupFilter.getSelectedNewsgroups().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getSelectedNewsgroups().size());
         final Vector<NewsGroup> topsNewsgroups = new Vector<>();
         topsNewsgroups.add(Mockito.mock(NewsGroup.class));
         this.newsGroupFilter.setSelectedNewsgroups(topsNewsgroups);
-        Assert.assertEquals(1, this.newsGroupFilter.getSelectedNewsgroups().size());
+        Assertions.assertEquals(1, this.newsGroupFilter.getSelectedNewsgroups().size());
         this.newsGroupFilter.clear();
-        Assert.assertEquals(0, this.newsGroupFilter.getSelectedNewsgroups().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getSelectedNewsgroups().size());
     }
 
     @Test
     public final void testSelectedNewsgroupsNotFiltered() {
         this.newsGroupFilter.setFiltered(false);
-        Assert.assertNull(this.newsGroupFilter.getSelectedNewsgroups());
+        Assertions.assertNull(this.newsGroupFilter.getSelectedNewsgroups());
     }
 
     @Test
     public final void testSelectedPosters() {
         this.newsGroupFilter.setFiltered(true);
-        Assert.assertEquals(0, this.newsGroupFilter.getSelectedPosters().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getSelectedPosters().size());
         final Vector<UsenetUser> topsNewsgroups = new Vector<>();
         topsNewsgroups.add(Mockito.mock(UsenetUser.class));
         this.newsGroupFilter.setSelectedPosters(topsNewsgroups);
-        Assert.assertEquals(1, this.newsGroupFilter.getSelectedPosters().size());
+        Assertions.assertEquals(1, this.newsGroupFilter.getSelectedPosters().size());
         this.newsGroupFilter.clear();
-        Assert.assertEquals(0, this.newsGroupFilter.getSelectedPosters().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getSelectedPosters().size());
     }
 
     @Test
     public final void testSelectedPostersNotFiltered() {
         this.newsGroupFilter.setFiltered(false);
-        Assert.assertNull(this.newsGroupFilter.getSelectedPosters());
+        Assertions.assertNull(this.newsGroupFilter.getSelectedPosters());
     }
 
     @Test
     public final void testTopicsFilter() {
-        Assert.assertEquals(0, this.newsGroupFilter.getTopicsFilter().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getTopicsFilter().size());
         final Set<Topic> countriesFilter = new HashSet<>();
         countriesFilter.add(Mockito.mock(Topic.class));
         this.newsGroupFilter.setTopicsFilter(countriesFilter);
-        Assert.assertEquals(1, this.newsGroupFilter.getTopicsFilter().size());
+        Assertions.assertEquals(1, this.newsGroupFilter.getTopicsFilter().size());
         this.newsGroupFilter.clear();
-        Assert.assertEquals(0, this.newsGroupFilter.getTopicsFilter().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getTopicsFilter().size());
 
     }
 
     @Test
     public final void testTopsNewsgroups() {
-        Assert.assertEquals(0, this.newsGroupFilter.getTopsNewsgroups().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getTopsNewsgroups().size());
         final Set<NewsGroup> topsNewsgroups = new HashSet<>();
         topsNewsgroups.add(Mockito.mock(NewsGroup.class));
         this.newsGroupFilter.setTopsNewsgroups(topsNewsgroups);
-        Assert.assertEquals(1, this.newsGroupFilter.getTopsNewsgroups().size());
+        Assertions.assertEquals(1, this.newsGroupFilter.getTopsNewsgroups().size());
         this.newsGroupFilter.clear();
-        Assert.assertEquals(0, this.newsGroupFilter.getTopsNewsgroups().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getTopsNewsgroups().size());
     }
 
     @Test
     public final void testUsenetUsersFilter() {
-        Assert.assertEquals(0, this.newsGroupFilter.getUsenetUsersFilter().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getUsenetUsersFilter().size());
         final Vector<UsenetUser> filter = new Vector<>();
         filter.add(Mockito.mock(UsenetUser.class));
         this.newsGroupFilter.setUsenetUsersFilter(filter);
-        Assert.assertEquals(1, this.newsGroupFilter.getUsenetUsersFilter().size());
+        Assertions.assertEquals(1, this.newsGroupFilter.getUsenetUsersFilter().size());
         this.newsGroupFilter.clear();
-        Assert.assertEquals(0, this.newsGroupFilter.getUsenetUsersFilter().size());
+        Assertions.assertEquals(0, this.newsGroupFilter.getUsenetUsersFilter().size());
 
     }
 

--- a/src/test/java/uk/co/sleonard/unison/UNISoNAnalysisTest.java
+++ b/src/test/java/uk/co/sleonard/unison/UNISoNAnalysisTest.java
@@ -11,9 +11,9 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import org.hibernate.SQLQuery;
 import org.hibernate.Session;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
@@ -33,7 +33,7 @@ public class UNISoNAnalysisTest {
     private Topic topic;
     private NewsGroup newsgroup;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.session = Mockito.mock(Session.class);
         final UNISoNGUI gui = Mockito.mock(UNISoNGUI.class);
@@ -66,25 +66,25 @@ public class UNISoNAnalysisTest {
     @Test
     public final void testGetTopCountriesList() {
         final List<ResultRow> results = this.analysis.getTopCountriesList();
-        Assert.assertEquals(1, results.size());
-        Assert.assertEquals("UK", results.get(0).getKey());
-        Assert.assertEquals(2, results.get(0).getCount());
+        Assertions.assertEquals(1, results.size());
+        Assertions.assertEquals("UK", results.get(0).getKey());
+        Assertions.assertEquals(2, results.get(0).getCount());
     }
 
     @Test
     public final void testGetTopGroupsList() {
         final List<ResultRow> results = this.analysis.getTopGroupsList();
-        Assert.assertEquals(1, results.size());
-        Assert.assertEquals(this.newsgroup, results.get(0).getKey());
-        Assert.assertEquals(2, results.get(0).getCount());
+        Assertions.assertEquals(1, results.size());
+        Assertions.assertEquals(this.newsgroup, results.get(0).getKey());
+        Assertions.assertEquals(2, results.get(0).getCount());
     }
 
     @Test
     public final void testGetTopPosters() {
         final Vector<ResultRow> results = this.analysis.getTopPosters();
-        Assert.assertEquals(1, results.size());
-        Assert.assertEquals(this.poster, results.get(0).getKey());
-        Assert.assertEquals(2, results.get(0).getCount());
+        Assertions.assertEquals(1, results.size());
+        Assertions.assertEquals(this.poster, results.get(0).getKey());
+        Assertions.assertEquals(2, results.get(0).getCount());
     }
 
 }

--- a/src/test/java/uk/co/sleonard/unison/UNISoNControllerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/UNISoNControllerTest.java
@@ -1,6 +1,6 @@
 package uk.co.sleonard.unison;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.co.sleonard.unison.datahandling.DAO.NewsGroup;
 import uk.co.sleonard.unison.input.DataHibernatorPoolImpl;
 
@@ -8,7 +8,7 @@ import javax.swing.ListModel;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for {@link UNISoNController} that operate fully in memory.

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/DownloadRequestTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/DownloadRequestTest.java
@@ -1,9 +1,9 @@
 package uk.co.sleonard.unison.datahandling.DAO;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest.DownloadMode;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * The Class DownloadRequestTest.

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/EmailAddressTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/EmailAddressTest.java
@@ -6,10 +6,10 @@
  */
 package uk.co.sleonard.unison.datahandling.DAO;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The Class EmailAddressTest.
@@ -27,7 +27,7 @@ public class EmailAddressTest {
     public void testGetEmail() {
         final String expected = "email";
         final EmailAddress actual = new EmailAddress(null, expected, null);
-        Assert.assertEquals(expected, actual.getEmail());
+        Assertions.assertEquals(expected, actual.getEmail());
     }
 
     /**
@@ -37,7 +37,7 @@ public class EmailAddressTest {
     public void testGetIpAddress() {
         final String expected = "ipAddress";
         final EmailAddress actual = new EmailAddress(null, null, expected);
-        Assert.assertEquals(expected, actual.getIpAddress());
+        Assertions.assertEquals(expected, actual.getIpAddress());
     }
 
     /**
@@ -47,7 +47,7 @@ public class EmailAddressTest {
     public void testGetName() {
         final String expected = "name";
         final EmailAddress actual = new EmailAddress(expected, null, null);
-        Assert.assertEquals(expected, actual.getName());
+        Assertions.assertEquals(expected, actual.getName());
     }
 
     /**

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/GUIItemTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/GUIItemTest.java
@@ -6,8 +6,8 @@
  */
 package uk.co.sleonard.unison.datahandling.DAO;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * The Class GUIItem.
@@ -26,8 +26,8 @@ public class GUIItemTest {
     public void testGetItemAndToString() {
         final NewsGroup expected = new NewsGroup();
         this.guiItem = new GUIItem<>("name", expected);
-        Assert.assertEquals("name", this.guiItem.toString());
-        Assert.assertNotNull(this.guiItem.getObject());
+        Assertions.assertEquals("name", this.guiItem.toString());
+        Assertions.assertNotNull(this.guiItem.getObject());
     }
 
 }

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/IpAddressTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/IpAddressTest.java
@@ -6,8 +6,8 @@
  */
 package uk.co.sleonard.unison.datahandling.DAO;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * The Class IpAddressTest.
@@ -23,7 +23,7 @@ public class IpAddressTest {
      */
     @Test
     public void testGetId() {
-        Assert.assertEquals(0, new IpAddress().getId());
+        Assertions.assertEquals(0, new IpAddress().getId());
     }
 
     /**
@@ -33,11 +33,11 @@ public class IpAddressTest {
     public void testGetIpAddress() {
         final String expected = "127.0.0.1";
         IpAddress actual = new IpAddress();
-        Assert.assertNull(actual.getIpAddress());
+        Assertions.assertNull(actual.getIpAddress());
         actual.setIpAddress(expected);
-        Assert.assertEquals(expected, actual.getIpAddress());
+        Assertions.assertEquals(expected, actual.getIpAddress());
         actual = new IpAddress(expected, null);
-        Assert.assertEquals(expected, actual.getIpAddress()); // Constructor Test
+        Assertions.assertEquals(expected, actual.getIpAddress()); // Constructor Test
     }
 
     /**
@@ -48,11 +48,11 @@ public class IpAddressTest {
         final Location expected = new Location();
         expected.setCity("Madrid");
         IpAddress actual = new IpAddress();
-        Assert.assertNull(actual.getLocation());
+        Assertions.assertNull(actual.getLocation());
         actual.setLocation(expected);
-        Assert.assertEquals(expected.getCity(), actual.getLocation().getCity());
+        Assertions.assertEquals(expected.getCity(), actual.getLocation().getCity());
         actual = new IpAddress(null, expected);
-        Assert.assertEquals(expected.getCity(), actual.getLocation().getCity()); // Constructor
+        Assertions.assertEquals(expected.getCity(), actual.getLocation().getCity()); // Constructor
         // Test
     }
 
@@ -65,7 +65,7 @@ public class IpAddressTest {
         final TestIpAddress actual2 = new TestIpAddress();
         actual1.setIpAddress("124");
         actual2.setIpAddress("556");
-        Assert.assertTrue(actual1.hashCode() != actual2.hashCode());
+        Assertions.assertTrue(actual1.hashCode() != actual2.hashCode());
     }
 
 }

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/LocationTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/LocationTest.java
@@ -6,8 +6,8 @@
  */
 package uk.co.sleonard.unison.datahandling.DAO;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -45,29 +45,29 @@ public class LocationTest {
                 LocationTest.countryCode, guessed, posters, ipAddresses);
         Location l2 = new Location(LocationTest.city, LocationTest.country,
                 LocationTest.countryCode, !guessed, posters, ipAddresses);
-        Assert.assertTrue(l1.equals(l1));
-        Assert.assertEquals(l1, l1);
-        Assert.assertFalse(l1.equals(l2));
-        Assert.assertNotEquals(l1, l2);
+        Assertions.assertTrue(l1.equals(l1));
+        Assertions.assertEquals(l1, l1);
+        Assertions.assertFalse(l1.equals(l2));
+        Assertions.assertNotEquals(l1, l2);
         l2 = new Location(LocationTest.city + "Wrong", LocationTest.country,
                 LocationTest.countryCode, guessed, posters, ipAddresses);
-        Assert.assertNotEquals(l1, l2);
+        Assertions.assertNotEquals(l1, l2);
         l2 = new Location(LocationTest.city, LocationTest.country + "Wrong",
                 LocationTest.countryCode, guessed, posters, ipAddresses);
-        Assert.assertNotEquals(l1, l2);
+        Assertions.assertNotEquals(l1, l2);
         l2 = new Location(LocationTest.city, LocationTest.country,
                 LocationTest.countryCode + "Wrong", guessed, posters, ipAddresses);
-        Assert.assertNotEquals(l1, l2);
+        Assertions.assertNotEquals(l1, l2);
         final List<UsenetUser> posters2 = new ArrayList<>();
         posters2.add(Mockito.mock(UsenetUser.class));
         l2 = new Location(LocationTest.city, LocationTest.country, LocationTest.countryCode,
                 guessed, posters2, ipAddresses);
-        Assert.assertNotEquals(l1, l2);
+        Assertions.assertNotEquals(l1, l2);
         final List<IpAddress> ipAdddresses2 = new ArrayList<>();
         ipAdddresses2.add(Mockito.mock(IpAddress.class));
         l2 = new Location(LocationTest.city, LocationTest.country, LocationTest.countryCode,
                 guessed, posters, ipAdddresses2);
-        Assert.assertNotEquals(l1, l2);
+        Assertions.assertNotEquals(l1, l2);
 
     }
 
@@ -80,7 +80,7 @@ public class LocationTest {
                 + LocationTest.countryCode + ")";
         final Location actual = new Location(LocationTest.city, LocationTest.country,
                 LocationTest.countryCode, true, null, null);
-        Assert.assertEquals(expected, actual.fullString());
+        Assertions.assertEquals(expected, actual.fullString());
     }
 
     /**
@@ -90,9 +90,9 @@ public class LocationTest {
     public void testGetCity() {
         final String expected = LocationTest.city;
         final Location actual = new Location();
-        Assert.assertNull(actual.getCity());
+        Assertions.assertNull(actual.getCity());
         actual.setCity(expected);
-        Assert.assertEquals(expected, actual.getCity());
+        Assertions.assertEquals(expected, actual.getCity());
     }
 
     /**
@@ -102,9 +102,9 @@ public class LocationTest {
     public void testGetCountry() {
         final String expected = LocationTest.country;
         final Location actual = new Location();
-        Assert.assertNull(actual.getCountry());
+        Assertions.assertNull(actual.getCountry());
         actual.setCountry(expected);
-        Assert.assertEquals(expected, actual.getCountry());
+        Assertions.assertEquals(expected, actual.getCountry());
     }
 
     /**
@@ -114,9 +114,9 @@ public class LocationTest {
     public void testGetCountryCode() {
         final String expected = LocationTest.countryCode;
         final Location actual = new Location();
-        Assert.assertNull(actual.getCountryCode());
+        Assertions.assertNull(actual.getCountryCode());
         actual.setCountryCode(expected);
-        Assert.assertEquals(expected, actual.getCountryCode());
+        Assertions.assertEquals(expected, actual.getCountryCode());
     }
 
     /**
@@ -124,7 +124,7 @@ public class LocationTest {
      */
     @Test
     public void testGetId() {
-        Assert.assertEquals(0, new Location().getId());
+        Assertions.assertEquals(0, new Location().getId());
     }
 
     /**
@@ -134,10 +134,10 @@ public class LocationTest {
     public void testGetIpAddresses() {
         final List<IpAddress> expected = new ArrayList<>();
         final Location actual = new Location();
-        Assert.assertEquals(expected.size(), actual.getIpAddresses().size());
+        Assertions.assertEquals(expected.size(), actual.getIpAddresses().size());
         expected.add(new IpAddress());
         actual.setIpAddresses(expected);
-        Assert.assertEquals(expected.size(), actual.getIpAddresses().size());
+        Assertions.assertEquals(expected.size(), actual.getIpAddresses().size());
     }
 
     /**
@@ -147,10 +147,10 @@ public class LocationTest {
     public void testGetPosters() {
         final List<UsenetUser> expected = new ArrayList<>();
         final Location actual = new Location();
-        Assert.assertEquals(expected.size(), actual.getPosters().size());
+        Assertions.assertEquals(expected.size(), actual.getPosters().size());
         expected.add(new UsenetUser());
         actual.setPosters(expected);
-        Assert.assertEquals(expected.size(), actual.getPosters().size());
+        Assertions.assertEquals(expected.size(), actual.getPosters().size());
     }
 
     /**
@@ -162,7 +162,7 @@ public class LocationTest {
         final TestLocation actual2 = new TestLocation();
         actual1.setCity("testa");
         actual2.setCity("test3");
-        Assert.assertTrue(actual1.hashCode() != actual2.hashCode());
+        Assertions.assertTrue(actual1.hashCode() != actual2.hashCode());
     }
 
     /**
@@ -171,9 +171,9 @@ public class LocationTest {
     @Test
     public void testIsGuessed() {
         final Location actual = new Location();
-        Assert.assertFalse(actual.isGuessed());
+        Assertions.assertFalse(actual.isGuessed());
         actual.setGuessed(true);
-        Assert.assertTrue(actual.isGuessed());
+        Assertions.assertTrue(actual.isGuessed());
     }
 
     /**
@@ -184,7 +184,7 @@ public class LocationTest {
         final String expected = LocationTest.city + " - " + LocationTest.countryCode;
         final Location actual = new Location(LocationTest.city, null, LocationTest.countryCode,
                 true, null, null);
-        Assert.assertEquals(expected, actual.toString());
+        Assertions.assertEquals(expected, actual.toString());
     }
 
 }

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/MessageTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/MessageTest.java
@@ -6,8 +6,8 @@
  */
 package uk.co.sleonard.unison.datahandling.DAO;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
@@ -36,23 +36,23 @@ public class MessageTest {
         actual = new Message(expected1, expected2, expected3, expected4, expected5, expected6,
                 expected7, expected8);
 
-        Assert.assertEquals(expected1, actual.getDateCreated());
-        Assert.assertEquals(expected2, actual.getUsenetMessageID());
-        Assert.assertEquals(expected3, actual.getSubject());
-        Assert.assertEquals(expected4, actual.getPoster());
-        Assert.assertEquals(expected5, actual.getTopic());
-        Assert.assertEquals(expected6, actual.getNewsgroups());
-        Assert.assertEquals(expected7, actual.getReferencedMessages());
-        Assert.assertArrayEquals(expected8, actual.getMessageBody());
+        Assertions.assertEquals(expected1, actual.getDateCreated());
+        Assertions.assertEquals(expected2, actual.getUsenetMessageID());
+        Assertions.assertEquals(expected3, actual.getSubject());
+        Assertions.assertEquals(expected4, actual.getPoster());
+        Assertions.assertEquals(expected5, actual.getTopic());
+        Assertions.assertEquals(expected6, actual.getNewsgroups());
+        Assertions.assertEquals(expected7, actual.getReferencedMessages());
+        Assertions.assertArrayEquals(expected8, actual.getMessageBody());
 
         actual = new Message(expected1, expected2, expected3, expected4, expected5, expected6,
                 expected7, expected8);
-        Assert.assertEquals(expected1, actual.getDateCreated());
-        Assert.assertEquals(expected2, actual.getUsenetMessageID());
-        Assert.assertEquals(expected3, actual.getSubject());
-        Assert.assertEquals(expected4, actual.getPoster());
-        Assert.assertEquals(expected5, actual.getTopic());
-        Assert.assertArrayEquals(expected8, actual.getMessageBody());
+        Assertions.assertEquals(expected1, actual.getDateCreated());
+        Assertions.assertEquals(expected2, actual.getUsenetMessageID());
+        Assertions.assertEquals(expected3, actual.getSubject());
+        Assertions.assertEquals(expected4, actual.getPoster());
+        Assertions.assertEquals(expected5, actual.getTopic());
+        Assertions.assertArrayEquals(expected8, actual.getMessageBody());
     }
 
     @Test
@@ -71,11 +71,11 @@ public class MessageTest {
                 new HashSet<>(newsgroups), referencedMessages,
                 Arrays.copyOf(messageBody, messageBody.length));
 
-        Assert.assertEquals(m1, m2);
-        Assert.assertEquals(m1.hashCode(), m2.hashCode());
+        Assertions.assertEquals(m1, m2);
+        Assertions.assertEquals(m1.hashCode(), m2.hashCode());
 
         m2.setSubject("Different");
-        Assert.assertNotEquals(m1, m2);
+        Assertions.assertNotEquals(m1, m2);
     }
 
     /**
@@ -85,9 +85,9 @@ public class MessageTest {
     public void testGetDateCreated() {
         final Date expected = Calendar.getInstance().getTime();
         final Message actual = new Message();
-        Assert.assertNull(actual.getDateCreated());
+        Assertions.assertNull(actual.getDateCreated());
         actual.setDateCreated(expected);
-        Assert.assertEquals(0, expected.compareTo(actual.getDateCreated()));
+        Assertions.assertEquals(0, expected.compareTo(actual.getDateCreated()));
     }
 
     /**
@@ -95,7 +95,7 @@ public class MessageTest {
      */
     @Test
     public void testGetId() {
-        Assert.assertEquals(0, new Message().getId());
+        Assertions.assertEquals(0, new Message().getId());
     }
 
     /**
@@ -105,9 +105,9 @@ public class MessageTest {
     public void testGetMessageBody() {
         final byte[] expecteds = {0, 1, 2, 3, 4};
         final Message actuals = new Message();
-        Assert.assertNull(actuals.getMessageBody());
+        Assertions.assertNull(actuals.getMessageBody());
         actuals.setMessageBody(expecteds);
-        Assert.assertArrayEquals(expecteds, actuals.getMessageBody());
+        Assertions.assertArrayEquals(expecteds, actuals.getMessageBody());
     }
 
     /**
@@ -117,10 +117,10 @@ public class MessageTest {
     public void testGetNewsgroups() {
         final Set<NewsGroup> expected = new HashSet<>();
         final Message actual = new Message();
-        Assert.assertEquals(expected.size(), actual.getNewsgroups().size());
+        Assertions.assertEquals(expected.size(), actual.getNewsgroups().size());
         expected.add(new NewsGroup());
         actual.setNewsgroups(expected);
-        Assert.assertEquals(expected.size(), actual.getNewsgroups().size());
+        Assertions.assertEquals(expected.size(), actual.getNewsgroups().size());
     }
 
     /**
@@ -130,9 +130,9 @@ public class MessageTest {
     public void testGetPoster() {
         final UsenetUser expected = new UsenetUser();
         final Message actual = new Message();
-        Assert.assertNull(actual.getPoster());
+        Assertions.assertNull(actual.getPoster());
         actual.setPoster(expected);
-        Assert.assertEquals(expected, actual.getPoster());
+        Assertions.assertEquals(expected, actual.getPoster());
     }
 
     /**
@@ -142,9 +142,9 @@ public class MessageTest {
     public void testGetReferencedMessages() {
         final String expected = new String("refMess");
         final Message actual = new Message();
-        Assert.assertNull(actual.getReferencedMessages());
+        Assertions.assertNull(actual.getReferencedMessages());
         actual.setReferencedMessages(expected);
-        Assert.assertEquals(expected, actual.getReferencedMessages());
+        Assertions.assertEquals(expected, actual.getReferencedMessages());
     }
 
     /**
@@ -154,9 +154,9 @@ public class MessageTest {
     public void testGetSubject() {
         final String expected = new String("subject");
         final Message actual = new Message();
-        Assert.assertNull(actual.getSubject());
+        Assertions.assertNull(actual.getSubject());
         actual.setSubject(expected);
-        Assert.assertEquals(expected, actual.getSubject());
+        Assertions.assertEquals(expected, actual.getSubject());
     }
 
     /**
@@ -167,9 +167,9 @@ public class MessageTest {
         final Topic expected = new Topic();
         expected.setSubject("sub");
         final Message actual = new Message();
-        Assert.assertNull(actual.getTopic());
+        Assertions.assertNull(actual.getTopic());
         actual.setTopic(expected);
-        Assert.assertEquals(expected.getSubject(), actual.getTopic().getSubject());
+        Assertions.assertEquals(expected.getSubject(), actual.getTopic().getSubject());
     }
 
     /**
@@ -179,9 +179,9 @@ public class MessageTest {
     public void testGetUsenetMessageID() {
         final String expected = new String("usenetMessId");
         final Message actual = new Message();
-        Assert.assertNull(actual.getUsenetMessageID());
+        Assertions.assertNull(actual.getUsenetMessageID());
         actual.setUsenetMessageID(expected);
-        Assert.assertEquals(expected, actual.getUsenetMessageID());
+        Assertions.assertEquals(expected, actual.getUsenetMessageID());
     }
 
     /**
@@ -193,7 +193,7 @@ public class MessageTest {
         final TestMessage actual2 = new TestMessage();
         actual1.setSubject("abc");
         actual2.setSubject("def");
-        Assert.assertTrue(actual1.hashCode() != actual2.hashCode());
+        Assertions.assertTrue(actual1.hashCode() != actual2.hashCode());
     }
 
     /**
@@ -204,7 +204,7 @@ public class MessageTest {
         final String expected = "Subject:null";
         final Message actual = new Message();
         actual.setSubject("Subject");
-        Assert.assertEquals(expected, actual.toString());
+        Assertions.assertEquals(expected, actual.toString());
     }
 
 }

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/NewsGroupTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/NewsGroupTest.java
@@ -8,9 +8,9 @@ package uk.co.sleonard.unison.datahandling.DAO;
 
 import org.apache.commons.net.nntp.NewsgroupInfo;
 import org.apache.commons.net.nntp.NewsgroupInfoFactory;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -65,9 +65,9 @@ public class NewsGroupTest {
     public void getLastIndexDownloaded() {
         final int expected = 10;
         final NewsGroup actual = new NewsGroup();
-        Assert.assertEquals(0, actual.getLastIndexDownloaded());
+        Assertions.assertEquals(0, actual.getLastIndexDownloaded());
         actual.setLastIndexDownloaded(expected);
-        Assert.assertEquals(expected, actual.getLastIndexDownloaded());
+        Assertions.assertEquals(expected, actual.getLastIndexDownloaded());
     }
 
     /**
@@ -77,9 +77,9 @@ public class NewsGroupTest {
     public void getLastMessage() {
         final int expected = 10;
         final NewsGroup actual = new NewsGroup();
-        Assert.assertEquals(0, actual.getLastMessage());
+        Assertions.assertEquals(0, actual.getLastMessage());
         actual.setLastMessage(expected);
-        Assert.assertEquals(expected, actual.getLastMessage());
+        Assertions.assertEquals(expected, actual.getLastMessage());
     }
 
     /**
@@ -87,7 +87,7 @@ public class NewsGroupTest {
      *
      * @throws Exception the exception
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final NewsgroupInfo ngInfoMock = this.generateNewsgroupInfoMock();
         this.nntpNG = new NewsGroup(ngInfoMock);
@@ -102,7 +102,7 @@ public class NewsGroupTest {
         expected.setName("ng1");
         final NewsGroup actual = new NewsGroup();
         actual.setName("ng1");
-        Assert.assertEquals(0, actual.compareTo(expected));
+        Assertions.assertEquals(0, actual.compareTo(expected));
     }
 
     /**
@@ -110,7 +110,7 @@ public class NewsGroupTest {
      */
     @Test
     public void testGetArticleCount() {
-        Assert.assertEquals(NewsGroupTest.expectedArticleCount, this.nntpNG.getArticleCount());
+        Assertions.assertEquals(NewsGroupTest.expectedArticleCount, this.nntpNG.getArticleCount());
     }
 
     /**
@@ -118,12 +118,12 @@ public class NewsGroupTest {
      */
     @Test
     public void testGetFirstMessage() {
-        Assert.assertEquals(NewsGroupTest.expectedFirstMessage, this.nntpNG.getFirstMessage());
+        Assertions.assertEquals(NewsGroupTest.expectedFirstMessage, this.nntpNG.getFirstMessage());
         final int expected = 10;
         final NewsGroup actual = new NewsGroup();
-        Assert.assertEquals(0, actual.getFirstMessage());
+        Assertions.assertEquals(0, actual.getFirstMessage());
         actual.setFirstMessage(expected);
-        Assert.assertEquals(expected, actual.getFirstMessage());
+        Assertions.assertEquals(expected, actual.getFirstMessage());
     }
 
     /**
@@ -133,9 +133,9 @@ public class NewsGroupTest {
     public void testGetFullName() {
         final String expected = "fullname";
         final NewsGroup actual = new NewsGroup();
-        Assert.assertNull(actual.getFullName());
+        Assertions.assertNull(actual.getFullName());
         actual.setFullName(expected);
-        Assert.assertEquals(expected, actual.getFullName());
+        Assertions.assertEquals(expected, actual.getFullName());
     }
 
     /**
@@ -143,7 +143,7 @@ public class NewsGroupTest {
      */
     @Test
     public void testGetId() {
-        Assert.assertEquals(0, new NewsGroup().getId());
+        Assertions.assertEquals(0, new NewsGroup().getId());
     }
 
     /**
@@ -151,7 +151,7 @@ public class NewsGroupTest {
      */
     @Test
     public void testGetLastMessage() {
-        Assert.assertEquals(NewsGroupTest.expectedLastMessage, this.nntpNG.getLastMessage());
+        Assertions.assertEquals(NewsGroupTest.expectedLastMessage, this.nntpNG.getLastMessage());
     }
 
     /**
@@ -161,9 +161,9 @@ public class NewsGroupTest {
     public void testGetLastMessageTotal() {
         final int expected = 10;
         final NewsGroup actual = new NewsGroup();
-        Assert.assertEquals(0, actual.getLastMessageTotal());
+        Assertions.assertEquals(0, actual.getLastMessageTotal());
         actual.setLastMessageTotal(expected);
-        Assert.assertEquals(expected, actual.getLastMessageTotal());
+        Assertions.assertEquals(expected, actual.getLastMessageTotal());
     }
 
     /**
@@ -173,10 +173,10 @@ public class NewsGroupTest {
     public void testGetMessages() {
         final Set<Message> expected = new HashSet<>(0);
         final NewsGroup actual = new NewsGroup();
-        Assert.assertEquals(expected.size(), actual.getMessages().size());
+        Assertions.assertEquals(expected.size(), actual.getMessages().size());
         expected.add(new Message());
         actual.setMessages(expected);
-        Assert.assertEquals(expected.size(), actual.getMessages().size());
+        Assertions.assertEquals(expected.size(), actual.getMessages().size());
     }
 
     /**
@@ -186,9 +186,9 @@ public class NewsGroupTest {
     public void testGetName() {
         final String expected = "myname";
         final NewsGroup actual = new NewsGroup();
-        Assert.assertNull(actual.getName());
+        Assertions.assertNull(actual.getName());
         actual.setName(expected);
-        Assert.assertEquals(expected, actual.getName());
+        Assertions.assertEquals(expected, actual.getName());
     }
 
     /**
@@ -199,9 +199,9 @@ public class NewsGroupTest {
         final NewsGroup expected = new NewsGroup("alt.news", null, null, null, 1, 2, 1, 2, null,
                 true);
         final NewsGroup actual = new NewsGroup();
-        Assert.assertNull(actual.getParentNewsGroup());
+        Assertions.assertNull(actual.getParentNewsGroup());
         actual.setParentNewsGroup(expected);
-        Assert.assertEquals(expected.getName(), actual.getParentNewsGroup().getName());
+        Assertions.assertEquals(expected.getName(), actual.getParentNewsGroup().getName());
     }
 
     /**
@@ -211,10 +211,10 @@ public class NewsGroupTest {
     public void testGetTopics() {
         final Set<Topic> expected = new HashSet<>(0);
         final NewsGroup actual = new NewsGroup();
-        Assert.assertEquals(expected.size(), actual.getTopics().size());
+        Assertions.assertEquals(expected.size(), actual.getTopics().size());
         expected.add(new Topic());
         actual.setTopics(expected);
-        Assert.assertEquals(expected.size(), actual.getTopics().size());
+        Assertions.assertEquals(expected.size(), actual.getTopics().size());
     }
 
     /**
@@ -225,7 +225,7 @@ public class NewsGroupTest {
         final TestNewsGroup actual2 = new TestNewsGroup();
         actual1.setFullName("abc");
         actual2.setFullName("def");
-        Assert.assertTrue(actual1.hashCode() != actual2.hashCode());
+        Assertions.assertTrue(actual1.hashCode() != actual2.hashCode());
     }
 
     /**
@@ -235,9 +235,9 @@ public class NewsGroupTest {
     public void testIsLastNode() {
         final boolean expected = true;
         final NewsGroup actual = new NewsGroup();
-        Assert.assertFalse(actual.isLastNode());
+        Assertions.assertFalse(actual.isLastNode());
         actual.setLastNode(expected);
-        Assert.assertEquals(expected, actual.isLastNode());
+        Assertions.assertEquals(expected, actual.isLastNode());
     }
 
     /**
@@ -250,7 +250,7 @@ public class NewsGroupTest {
         actual.setFullName("fullname");
         actual.setLastMessage(10);
         actual.setEstimatedArticleCount(10);
-        Assert.assertEquals(expected, actual.toString());
+        Assertions.assertEquals(expected, actual.toString());
     }
 
 }

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/ResultRowTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/ResultRowTest.java
@@ -1,8 +1,8 @@
 package uk.co.sleonard.unison.datahandling.DAO;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * The Class ResultRowTest.

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/TopicTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/TopicTest.java
@@ -6,8 +6,8 @@
  */
 package uk.co.sleonard.unison.datahandling.DAO;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -39,8 +39,8 @@ public class TopicTest {
         final Set<NewsGroup> expected2 = new HashSet<>();
 
         actual = new Topic(expected, expected2);
-        Assert.assertEquals(expected, actual.getSubject());
-        Assert.assertEquals(expected2, actual.getNewsgroups());
+        Assertions.assertEquals(expected, actual.getSubject());
+        Assertions.assertEquals(expected2, actual.getNewsgroups());
     }
 
     /**
@@ -48,7 +48,7 @@ public class TopicTest {
      */
     @Test
     public void testGetId() {
-        Assert.assertEquals(0, new Topic().getId());
+        Assertions.assertEquals(0, new Topic().getId());
     }
 
     /**
@@ -58,10 +58,10 @@ public class TopicTest {
     public void testGetNewsgroups() {
         final Set<NewsGroup> expected = new HashSet<>(0);
         final Topic actual = new Topic();
-        Assert.assertEquals(expected.size(), actual.getNewsgroups().size());
+        Assertions.assertEquals(expected.size(), actual.getNewsgroups().size());
         expected.add(new NewsGroup());
         actual.setNewsgroups(expected);
-        Assert.assertEquals(expected.size(), actual.getNewsgroups().size());
+        Assertions.assertEquals(expected.size(), actual.getNewsgroups().size());
     }
 
     /**
@@ -71,9 +71,9 @@ public class TopicTest {
     public void testGetSubject() {
         final String expected = "subject";
         final Topic actual = new Topic();
-        Assert.assertNull(actual.getSubject());
+        Assertions.assertNull(actual.getSubject());
         actual.setSubject(expected);
-        Assert.assertEquals(expected, actual.getSubject());
+        Assertions.assertEquals(expected, actual.getSubject());
     }
 
     /**
@@ -85,7 +85,7 @@ public class TopicTest {
         final TestTopic actual2 = new TestTopic();
         actual1.setSubject("abc");
         actual2.setSubject("def");
-        Assert.assertTrue(actual1.hashCode() != actual2.hashCode());
+        Assertions.assertTrue(actual1.hashCode() != actual2.hashCode());
     }
 
     /**
@@ -95,6 +95,6 @@ public class TopicTest {
     public void testToString() {
         final String expected = new String("subject");
         final Topic actual = new Topic(expected, null);
-        Assert.assertEquals(expected, actual.toString());
+        Assertions.assertEquals(expected, actual.toString());
     }
 }

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/UsenetUserPersistenceTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/UsenetUserPersistenceTest.java
@@ -4,8 +4,8 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -22,8 +22,8 @@ public class UsenetUserPersistenceTest {
 
         try (SessionFactory sf = cfg.buildSessionFactory();
              Session session = sf.openSession()) {
-            Assert.assertNotNull(sf.getClassMetadata(Location.class));
-            Assert.assertNotNull(sf.getClassMetadata(IpAddress.class));
+            Assertions.assertNotNull(sf.getClassMetadata(Location.class));
+            Assertions.assertNotNull(sf.getClassMetadata(IpAddress.class));
             Transaction tx = session.beginTransaction();
             Location location = new Location("City", "Country", "CC", false,
                     Collections.emptyList(), Collections.emptyList());
@@ -37,9 +37,9 @@ public class UsenetUserPersistenceTest {
 
             session.clear();
             UsenetUser fromDb = session.get(UsenetUser.class, user.getId());
-            Assert.assertNotNull(fromDb);
-            Assert.assertEquals("test@example.com", fromDb.getEmail());
-            Assert.assertEquals("City", fromDb.getLocation().getCity());
+            Assertions.assertNotNull(fromDb);
+            Assertions.assertEquals("test@example.com", fromDb.getEmail());
+            Assertions.assertEquals("City", fromDb.getLocation().getCity());
         }
     }
 }

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/UsenetUserTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/UsenetUserTest.java
@@ -6,8 +6,8 @@
  */
 package uk.co.sleonard.unison.datahandling.DAO;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extends UsenetUser to change setId(protected)
@@ -38,11 +38,11 @@ public class UsenetUserTest {
         final String expected4 = "Programming";
         final Location expected5 = new Location();
         actual = new UsenetUser(expected, expected2, expected3, expected4, expected5);
-        Assert.assertEquals(expected, actual.getName());
-        Assert.assertEquals(expected2, actual.getEmail());
-        Assert.assertEquals(expected3, actual.getIpaddress());
-        Assert.assertEquals(expected4, actual.getGender());
-        Assert.assertEquals(expected5, actual.getLocation());
+        Assertions.assertEquals(expected, actual.getName());
+        Assertions.assertEquals(expected2, actual.getEmail());
+        Assertions.assertEquals(expected3, actual.getIpaddress());
+        Assertions.assertEquals(expected4, actual.getGender());
+        Assertions.assertEquals(expected5, actual.getLocation());
     }
 
     /**
@@ -55,12 +55,12 @@ public class UsenetUserTest {
         original.setId(123);
 
         final UsenetUser copy = new UsenetUser(original);
-        Assert.assertEquals(original.getName(), copy.getName());
-        Assert.assertEquals(original.getEmail(), copy.getEmail());
-        Assert.assertEquals(original.getIpaddress(), copy.getIpaddress());
-        Assert.assertEquals(original.getGender(), copy.getGender());
-        Assert.assertEquals(original.getLocation(), copy.getLocation());
-        Assert.assertEquals(original.getId(), copy.getId());
+        Assertions.assertEquals(original.getName(), copy.getName());
+        Assertions.assertEquals(original.getEmail(), copy.getEmail());
+        Assertions.assertEquals(original.getIpaddress(), copy.getIpaddress());
+        Assertions.assertEquals(original.getGender(), copy.getGender());
+        Assertions.assertEquals(original.getLocation(), copy.getLocation());
+        Assertions.assertEquals(original.getId(), copy.getId());
     }
 
     /**
@@ -70,9 +70,9 @@ public class UsenetUserTest {
     public void testGetEmail() {
         final String expected = "user@email.com";
         final UsenetUser actual = new UsenetUser();
-        Assert.assertNull(actual.getEmail());
+        Assertions.assertNull(actual.getEmail());
         actual.setEmail(expected);
-        Assert.assertEquals(expected, actual.getEmail());
+        Assertions.assertEquals(expected, actual.getEmail());
     }
 
     /**
@@ -82,9 +82,9 @@ public class UsenetUserTest {
     public void testGetGender() {
         final String expected = "gender";
         final UsenetUser actual = new UsenetUser();
-        Assert.assertNull(actual.getGender());
+        Assertions.assertNull(actual.getGender());
         actual.setGender(expected);
-        Assert.assertEquals(expected, actual.getGender());
+        Assertions.assertEquals(expected, actual.getGender());
     }
 
     /**
@@ -92,7 +92,7 @@ public class UsenetUserTest {
      */
     @Test
     public void testGetId() {
-        Assert.assertEquals(0, new UsenetUser().getId());
+        Assertions.assertEquals(0, new UsenetUser().getId());
     }
 
     /**
@@ -102,9 +102,9 @@ public class UsenetUserTest {
     public void testGetIpaddress() {
         final String expected = "127.0.0.1";
         final UsenetUser actual = new UsenetUser();
-        Assert.assertNull(actual.getIpaddress());
+        Assertions.assertNull(actual.getIpaddress());
         actual.setIpaddress(expected);
-        Assert.assertEquals(expected, actual.getIpaddress());
+        Assertions.assertEquals(expected, actual.getIpaddress());
     }
 
     /**
@@ -114,9 +114,9 @@ public class UsenetUserTest {
     public void testGetLocation() {
         final Location expected = new Location(null, null, "BR", false, null, null);
         final UsenetUser actual = new UsenetUser();
-        Assert.assertNull(actual.getLocation());
+        Assertions.assertNull(actual.getLocation());
         actual.setLocation(expected);
-        Assert.assertEquals(expected.getCountryCode(), actual.getLocation().getCountryCode());
+        Assertions.assertEquals(expected.getCountryCode(), actual.getLocation().getCountryCode());
     }
 
     /**
@@ -126,9 +126,9 @@ public class UsenetUserTest {
     public void testGetName() {
         final String expected = "name";
         final UsenetUser actual = new UsenetUser();
-        Assert.assertNull(actual.getName());
+        Assertions.assertNull(actual.getName());
         actual.setName(expected);
-        Assert.assertEquals(expected, actual.getName());
+        Assertions.assertEquals(expected, actual.getName());
     }
 
     /**
@@ -140,7 +140,7 @@ public class UsenetUserTest {
         final TestUsenetUser actual2 = new TestUsenetUser();
         actual1.setEmail("a@2");
         actual2.setEmail("a@22");
-        Assert.assertTrue(actual1.hashCode() != actual2.hashCode());
+        Assertions.assertTrue(actual1.hashCode() != actual2.hashCode());
     }
 
     /**
@@ -151,7 +151,7 @@ public class UsenetUserTest {
         final String expected = "elton(elton_12_nunes@hotmail.com)";
         final UsenetUser actual = new UsenetUser("elton", "elton_12_nunes@hotmail.com", null,
                 expected, null);
-        Assert.assertEquals(expected, actual.toString());
+        Assertions.assertEquals(expected, actual.toString());
     }
 
 }

--- a/src/test/java/uk/co/sleonard/unison/datahandling/DataQueryTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DataQueryTest.java
@@ -1,8 +1,8 @@
 package uk.co.sleonard.unison.datahandling;
 
 import org.hibernate.Session;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import uk.co.sleonard.unison.datahandling.DAO.Message;
 import uk.co.sleonard.unison.datahandling.DAO.NewsGroup;
@@ -10,8 +10,8 @@ import uk.co.sleonard.unison.datahandling.DAO.UsenetUser;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,7 +29,7 @@ public class DataQueryTest {
     /**
      * Setup.
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         this.helper = mock(HibernateHelper.class);
         this.dataQuery = new DataQuery(this.helper);

--- a/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperFindOrCreateUsenetUserTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperFindOrCreateUsenetUserTest.java
@@ -1,7 +1,7 @@
 package uk.co.sleonard.unison.datahandling;
 
 import org.hibernate.Session;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.input.NewsArticle;
@@ -10,7 +10,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Date;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for {@link HibernateHelper#findOrCreateUsenetUser(NewsArticle, Session, String)}.

--- a/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperRunQueryTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperRunQueryTest.java
@@ -1,9 +1,9 @@
 package uk.co.sleonard.unison.datahandling;
 
 import org.hibernate.Session;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.datahandling.DAO.Message;
 import uk.co.sleonard.unison.datahandling.DAO.Topic;
@@ -11,15 +11,15 @@ import uk.co.sleonard.unison.datahandling.DAO.UsenetUser;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HibernateHelperRunQueryTest {
 
     private HibernateHelper helper;
     private Session session;
 
-    @Before
+    @BeforeEach
     public void setUp() throws UNISoNException {
         this.helper = new HibernateHelper(null);
         this.session = this.helper.getHibernateSession();
@@ -43,7 +43,7 @@ public class HibernateHelperRunQueryTest {
         this.session.getTransaction().commit();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         if (this.session != null) {
             this.session.close();

--- a/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperSetLocationTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperSetLocationTest.java
@@ -2,7 +2,7 @@ package uk.co.sleonard.unison.datahandling;
 
 import org.hibernate.Session;
 import org.hibernate.query.Query;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.co.sleonard.unison.datahandling.DAO.Location;
 import uk.co.sleonard.unison.datahandling.DAO.UsenetUser;

--- a/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperTest.java
@@ -1,6 +1,6 @@
 package uk.co.sleonard.unison.datahandling;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.datahandling.DAO.Message;
 import uk.co.sleonard.unison.datahandling.DAO.NewsGroup;
@@ -10,8 +10,8 @@ import uk.co.sleonard.unison.input.NewsArticle;
 
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link HibernateHelper}.

--- a/src/test/java/uk/co/sleonard/unison/datahandling/MessageCacheServiceTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/MessageCacheServiceTest.java
@@ -1,12 +1,12 @@
 package uk.co.sleonard.unison.datahandling;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.co.sleonard.unison.datahandling.DAO.Message;
 
 import java.util.Date;
 import java.util.HashSet;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for {@link MessageCacheService}.

--- a/src/test/java/uk/co/sleonard/unison/datahandling/MessageFactoryTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/MessageFactoryTest.java
@@ -1,6 +1,6 @@
 package uk.co.sleonard.unison.datahandling;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.datahandling.DAO.Message;
 import uk.co.sleonard.unison.datahandling.DAO.UsenetUser;
@@ -8,7 +8,7 @@ import uk.co.sleonard.unison.input.NewsArticle;
 
 import java.util.Date;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for {@link MessageFactory}.

--- a/src/test/java/uk/co/sleonard/unison/datahandling/SessionManagerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/SessionManagerTest.java
@@ -1,9 +1,9 @@
 package uk.co.sleonard.unison.datahandling;
 
 import org.hibernate.Session;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Tests for {@link SessionManager}.

--- a/src/test/java/uk/co/sleonard/unison/datahandling/UNISoNDatabaseTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/UNISoNDatabaseTest.java
@@ -7,9 +7,9 @@
 package uk.co.sleonard.unison.datahandling;
 
 import org.hibernate.Session;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import uk.co.sleonard.unison.NewsGroupFilter;
@@ -31,7 +31,7 @@ public class UNISoNDatabaseTest {
     private HibernateHelper helper2;
     private int i;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.filter2 = Mockito.mock(NewsGroupFilter.class);
         final Vector<Message> mesgs = new Vector<>();
@@ -60,18 +60,18 @@ public class UNISoNDatabaseTest {
         Mockito.when(this.helper2.runQuery(ArgumentMatchers.anyString(), ArgumentMatchers.nullable(Session.class),
                 ArgumentMatchers.any(Class.class))).thenReturn(messages);
         final Set<Message> result = this.database.getMessages(topic, this.session2);
-        Assert.assertEquals(1, result.size());
-        Assert.assertTrue(result.contains(msg));
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertTrue(result.contains(msg));
     }
 
     @Test
     public final void testNotifyListeners() {
-        Assert.assertEquals(0, this.i);
+        Assertions.assertEquals(0, this.i);
         this.database.addDataChangeListener(evt -> {
             this.i++;
         });
         this.database.notifyListeners();
-        Assert.assertEquals(1, this.i);
+        Assertions.assertEquals(1, this.i);
     }
 
     @Test

--- a/src/test/java/uk/co/sleonard/unison/datahandling/UsenetUserHelperTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/UsenetUserHelperTest.java
@@ -1,12 +1,12 @@
 package uk.co.sleonard.unison.datahandling;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.co.sleonard.unison.datahandling.DAO.EmailAddress;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * The Class UsenetUserHelperTest

--- a/src/test/java/uk/co/sleonard/unison/datahandling/UserFactoryTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/UserFactoryTest.java
@@ -1,15 +1,15 @@
 package uk.co.sleonard.unison.datahandling;
 
 import org.hibernate.Session;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.datahandling.DAO.Location;
 import uk.co.sleonard.unison.datahandling.DAO.UsenetUser;
 import uk.co.sleonard.unison.input.NewsArticle;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Tests for {@link UserFactory}.

--- a/src/test/java/uk/co/sleonard/unison/gui/generated/DownloadNewsPanelTest.java
+++ b/src/test/java/uk/co/sleonard/unison/gui/generated/DownloadNewsPanelTest.java
@@ -1,7 +1,7 @@
 package uk.co.sleonard.unison.gui.generated;
 
 import org.hibernate.Session;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.co.sleonard.unison.UNISoNController;
 import uk.co.sleonard.unison.datahandling.HibernateHelper;
@@ -11,7 +11,7 @@ import javax.swing.*;
 import java.lang.reflect.Field;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link DownloadNewsPanel}.

--- a/src/test/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewerTest.java
@@ -4,8 +4,8 @@
 package uk.co.sleonard.unison.gui.generated;
 
 import org.hibernate.Session;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.co.sleonard.unison.NewsGroupFilter;
 import uk.co.sleonard.unison.UNISoNController;
@@ -19,7 +19,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.lang.reflect.Field;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for {@link MessageStoreViewer}.
@@ -29,7 +29,7 @@ public class MessageStoreViewerTest {
     private UNISoNController controller;
     private NewsGroupFilter filter;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.controller = Mockito.mock(UNISoNController.class);
         this.filter = Mockito.mock(NewsGroupFilter.class);

--- a/src/test/java/uk/co/sleonard/unison/gui/generated/PajekPanelTest.java
+++ b/src/test/java/uk/co/sleonard/unison/gui/generated/PajekPanelTest.java
@@ -4,7 +4,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 import uk.co.sleonard.unison.UNISoNController;
@@ -18,8 +18,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Vector;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link PajekPanel}.

--- a/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
@@ -1,17 +1,12 @@
 package uk.co.sleonard.unison.input;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Tests for {@link DataHibernatorPoolImpl}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(DataHibernatorWorker.class)
 public class DataHibernatorPoolImplTest {
 
     /**
@@ -19,12 +14,11 @@ public class DataHibernatorPoolImplTest {
      */
     @Test
     public void testStopAllDownloadsDelegates() {
-        PowerMockito.mockStatic(DataHibernatorWorker.class);
+        try (MockedStatic<DataHibernatorWorker> mocked = Mockito.mockStatic(DataHibernatorWorker.class)) {
+            DataHibernatorPool pool = new DataHibernatorPoolImpl();
+            pool.stopAllDownloads();
 
-        DataHibernatorPool pool = new DataHibernatorPoolImpl();
-        pool.stopAllDownloads();
-
-        PowerMockito.verifyStatic(DataHibernatorWorker.class, Mockito.times(1));
-        DataHibernatorWorker.stopDownload();
+            mocked.verify(DataHibernatorWorker::stopDownload, Mockito.times(1));
+        }
     }
 }

--- a/src/test/java/uk/co/sleonard/unison/input/DataHibernatorWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/DataHibernatorWorkerTest.java
@@ -1,9 +1,9 @@
 package uk.co.sleonard.unison.input;
 
 import org.hibernate.Session;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.co.sleonard.unison.datahandling.HibernateHelper;
 
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class DataHibernatorWorkerTest {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    @Before
+    @BeforeEach
     public void clearWorkers() throws Exception {
         Field workersField = DataHibernatorWorker.class.getDeclaredField("workers");
         workersField.setAccessible(true);
@@ -52,7 +52,7 @@ public class DataHibernatorWorkerTest {
         DataHibernatorWorker.startHibernators(reader, helper, queue, session);
 
         ArrayList<DataHibernatorWorker> workers = (ArrayList<DataHibernatorWorker>) workersField.get(null);
-        Assert.assertEquals(expectedSize, workers.size());
+        Assertions.assertEquals(expectedSize, workers.size());
 
         // capture threads for state inspection
         Field threadVarField = SwingWorker.class.getDeclaredField("threadVar");
@@ -69,7 +69,7 @@ public class DataHibernatorWorkerTest {
         // ensure all threads terminated
         for (Thread t : threads) {
             t.join(1000);
-            Assert.assertFalse(t.isAlive());
+            Assertions.assertFalse(t.isAlive());
         }
 
         workers.clear();
@@ -121,9 +121,9 @@ public class DataHibernatorWorkerTest {
         thread.join(1000);
 
         int processed = stored.get();
-        Assert.assertTrue("Worker should process at least one message before interrupt",
+        Assertions.assertTrue("Worker should process at least one message before interrupt",
                 processed > 0);
-        Assert.assertTrue("Worker should not process all messages after interrupt",
+        Assertions.assertTrue("Worker should not process all messages after interrupt",
                 processed < 5);
     }
 }

--- a/src/test/java/uk/co/sleonard/unison/input/FullDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/FullDownloadWorkerTest.java
@@ -6,9 +6,9 @@
  */
 package uk.co.sleonard.unison.input;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import uk.co.sleonard.unison.UNISoNException;
@@ -42,7 +42,7 @@ public class FullDownloadWorkerTest {
      *
      * @throws Exception the exception
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.newsClient = Mockito.mock(NewsClient.class);
         this.outQueue = new LinkedBlockingQueue<>();
@@ -67,10 +67,10 @@ public class FullDownloadWorkerTest {
                     DownloadMode.ALL, nntpHost, queue,
                     this.newsClient, reader, helper);
 
-            // Assert.assertTrue(FullDownloadWorker.queueSize() >= 1);
+            // Assertions.assertTrue(FullDownloadWorker.queueSize() >= 1);
         } catch (final UNISoNException e) {
             e.printStackTrace();
-            Assert.fail("ERROR: " + e.getMessage());
+            Assertions.fail("ERROR: " + e.getMessage());
         }
     }
 
@@ -92,10 +92,10 @@ public class FullDownloadWorkerTest {
                     DownloadMode.HEADERS, nntpHost, queue,
                     this.newsClient, reader, helper);
 
-            // Assert.assertTrue(FullDownloadWorker.queueSize() >= 1);
+            // Assertions.assertTrue(FullDownloadWorker.queueSize() >= 1);
         } catch (final UNISoNException e) {
             e.printStackTrace();
-            Assert.fail("ERROR: " + e.getMessage());
+            Assertions.fail("ERROR: " + e.getMessage());
         }
     }
 
@@ -109,9 +109,9 @@ public class FullDownloadWorkerTest {
         try {
             actual = new FullDownloadWorker("server", new LinkedBlockingQueue(),
                     this.newsClient);
-            Assert.assertNotNull(actual);
+            Assertions.assertNotNull(actual);
         } catch (final UNISoNException e) {
-            Assert.fail("ERROR: " + e.getMessage());
+            Assertions.fail("ERROR: " + e.getMessage());
         }
     }
 
@@ -153,10 +153,10 @@ public class FullDownloadWorkerTest {
         final DownloadRequest request = new DownloadRequest("<id123>", DownloadMode.ALL);
         try {
             final NewsArticle actual = this.worker.downloadArticle(request);
-            Assert.assertNotNull(actual);
-            Assert.assertEquals("Test subject", actual.getSubject());
+            Assertions.assertNotNull(actual);
+            Assertions.assertEquals("Test subject", actual.getSubject());
         } catch (final UNISoNException e) {
-            Assert.fail("ERROR: " + e.getMessage());
+            Assertions.fail("ERROR: " + e.getMessage());
         }
 
     }

--- a/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
@@ -6,9 +6,9 @@
  */
 package uk.co.sleonard.unison.input;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import uk.co.sleonard.unison.UNISoNException;
@@ -38,7 +38,7 @@ public class HeaderDownloadWorkerTest {
     /**
      * Setup.
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.worker = new HeaderDownloadWorker(new LinkedBlockingQueue<>(),
                 Mockito.mock(Downloader.class));
@@ -50,9 +50,9 @@ public class HeaderDownloadWorkerTest {
     @Test
     public void testFinished() {
         this.worker.resume();
-        Assert.assertTrue(this.worker.isDownloading());
+        Assertions.assertTrue(this.worker.isDownloading());
         this.worker.finished();
-        Assert.assertFalse(this.worker.isDownloading());
+        Assertions.assertFalse(this.worker.isDownloading());
     }
 
     /**
@@ -82,12 +82,12 @@ public class HeaderDownloadWorkerTest {
         final NewsClient nc = Mockito.mock(NewsClient.class);
         final NewsGroupReader ngr = new NewsGroupReader(nc);
         final Date fromAndTo = Calendar.getInstance().getTime();
-        Assert.assertFalse(this.worker.isDownloading());
+        Assertions.assertFalse(this.worker.isDownloading());
 
         this.worker.initialise(ngr, 0, 1, "server", "newsgroup", DownloadMode.ALL,
                 fromAndTo, fromAndTo);
 
-        Assert.assertTrue(this.worker.isDownloading());
+        Assertions.assertTrue(this.worker.isDownloading());
     }
 
     /**
@@ -95,9 +95,9 @@ public class HeaderDownloadWorkerTest {
      */
     @Test
     public void testIsDownloading() {
-        Assert.assertFalse(this.worker.isDownloading());
+        Assertions.assertFalse(this.worker.isDownloading());
         this.worker.resume();
-        Assert.assertTrue(this.worker.isDownloading());
+        Assertions.assertTrue(this.worker.isDownloading());
     }
 
     /**
@@ -108,7 +108,7 @@ public class HeaderDownloadWorkerTest {
         final AtomicInteger counter = new AtomicInteger(0);
         this.worker.addDataChangeListener(evt -> counter.incrementAndGet());
         this.worker.notifyListeners();
-        Assert.assertEquals(1, counter.get());
+        Assertions.assertEquals(1, counter.get());
     }
 
     /**
@@ -117,9 +117,9 @@ public class HeaderDownloadWorkerTest {
     @Test
     public void testPause() {
         this.worker.resume();
-        Assert.assertTrue(this.worker.isDownloading());
+        Assertions.assertTrue(this.worker.isDownloading());
         this.worker.pause();
-        Assert.assertFalse(this.worker.isDownloading());
+        Assertions.assertFalse(this.worker.isDownloading());
     }
 
     @Test(expected = UNISoNException.class)
@@ -178,7 +178,7 @@ public class HeaderDownloadWorkerTest {
     @Test
     public void testQueueMessagesNullReader()
             throws InterruptedException, IOException, UNISoNException {
-        Assert.assertTrue(this.worker.queueMessages(new LinkedBlockingQueue<>(), null));
+        Assertions.assertTrue(this.worker.queueMessages(new LinkedBlockingQueue<>(), null));
     }
 
     /**
@@ -186,9 +186,9 @@ public class HeaderDownloadWorkerTest {
      */
     @Test
     public void testResume() {
-        Assert.assertFalse(this.worker.isDownloading());
+        Assertions.assertFalse(this.worker.isDownloading());
         this.worker.resume();
-        Assert.assertTrue(this.worker.isDownloading());
+        Assertions.assertTrue(this.worker.isDownloading());
     }
 
     /**
@@ -200,7 +200,7 @@ public class HeaderDownloadWorkerTest {
     public void testStoreArticleInfo() throws UNISoNException {
         final LinkedBlockingQueue<NewsArticle> queue = new LinkedBlockingQueue<>();
         final boolean actual = this.worker.storeArticleInfo(queue);
-        Assert.assertTrue(actual);
+        Assertions.assertTrue(actual);
     }
 
     @Test
@@ -226,7 +226,7 @@ public class HeaderDownloadWorkerTest {
                 .retrieveArticleInfo(Mockito.anyLong(), endCaptor.capture());
 
         for (final Long end : endCaptor.getAllValues()) {
-            Assert.assertTrue("Requested message beyond end index", end <= 600L);
+            Assertions.assertTrue("Requested message beyond end index", end <= 600L);
         }
     }
 

--- a/src/test/java/uk/co/sleonard/unison/input/LocationFinderImplTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/LocationFinderImplTest.java
@@ -6,9 +6,9 @@
  */
 package uk.co.sleonard.unison.input;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.co.sleonard.unison.datahandling.DAO.Location;
 
 import java.net.URL;
@@ -17,7 +17,7 @@ public class LocationFinderImplTest {
 
     private LocationFinderImpl finder;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final URL resource = this.getClass().getClassLoader().getResource("locationFinder/");
         this.finder = new LocationFinderImpl(resource.toString());
@@ -26,14 +26,14 @@ public class LocationFinderImplTest {
     @Test
     public final void testCreateLocation() {
         final Location actual = this.finder.createLocation("213.205.194.135");
-        Assert.assertNotNull(actual);
-        Assert.assertEquals("United Kingdom", actual.getCountry());
-        Assert.assertEquals("London", actual.getCity());
-        Assert.assertEquals("GB", actual.getCountryCode());
+        Assertions.assertNotNull(actual);
+        Assertions.assertEquals("United Kingdom", actual.getCountry());
+        Assertions.assertEquals("London", actual.getCity());
+        Assertions.assertEquals("GB", actual.getCountryCode());
 
         Location actual2 = this.finder.createLocation("wrongipaddress");
-        Assert.assertNull(actual2.getCountry());
-        Assert.assertNull(actual2.getCity());
-        Assert.assertNull(actual2.getCountryCode());
+        Assertions.assertNull(actual2.getCountry());
+        Assertions.assertNull(actual2.getCity());
+        Assertions.assertNull(actual2.getCountryCode());
     }
 }

--- a/src/test/java/uk/co/sleonard/unison/input/NewsArticleTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/NewsArticleTest.java
@@ -6,8 +6,8 @@
  */
 package uk.co.sleonard.unison.input;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import uk.co.sleonard.unison.UNISoNException;
 
 import java.text.ParseException;
@@ -29,9 +29,9 @@ public class NewsArticleTest {
     public void testGetArticleId() {
         final String expected = "articleId";
         final NewsArticle actual = new NewsArticle();
-        Assert.assertNull(actual.getArticleID());
+        Assertions.assertNull(actual.getArticleID());
         actual.setArticleId(expected);
-        Assert.assertEquals(expected, actual.getArticleID());
+        Assertions.assertEquals(expected, actual.getArticleID());
     }
 
     /**
@@ -50,9 +50,9 @@ public class NewsArticleTest {
     public void testGetContent() {
         final String expected = "content";
         final NewsArticle actual = new NewsArticle();
-        Assert.assertNull(actual.getContent());
+        Assertions.assertNull(actual.getContent());
         actual.setContent(expected);
-        Assert.assertEquals(expected, actual.getContent());
+        Assertions.assertEquals(expected, actual.getContent());
     }
 
     /**
@@ -65,11 +65,11 @@ public class NewsArticleTest {
     public void testGetDate() throws ParseException, UNISoNException {
         final String dateExpected = "Wed, 11 May 2016 13:10:00 GMT";
         final NewsArticle test = new NewsArticle();
-        Assert.assertNull(test.getDate());
+        Assertions.assertNull(test.getDate());
         test.setDate(dateExpected);
         final Calendar actual = Calendar.getInstance();
         actual.setTime(test.getDate());
-        Assert.assertEquals(4, actual.get(Calendar.MONTH));
+        Assertions.assertEquals(4, actual.get(Calendar.MONTH));
     }
 
     /**
@@ -79,9 +79,9 @@ public class NewsArticleTest {
     public void testGetFrom() {
         final String expected = "user";
         final NewsArticle actual = new NewsArticle();
-        Assert.assertNull(actual.getFrom());
+        Assertions.assertNull(actual.getFrom());
         actual.setFrom(expected);
-        Assert.assertEquals(expected, actual.getFrom());
+        Assertions.assertEquals(expected, actual.getFrom());
     }
 
     /**
@@ -104,7 +104,7 @@ public class NewsArticleTest {
         final NewsArticle test = new NewsArticle("article", 0, Calendar.getInstance().getTime(),
                 "from", null, null, null, newsgroups, null);
         final List<String> actual = test.getNewsgroupsList();
-        Assert.assertEquals(3, actual.size());
+        Assertions.assertEquals(3, actual.size());
     }
 
     /**
@@ -114,9 +114,9 @@ public class NewsArticleTest {
     public void testGetPostingHost() {
         final String expected = "posting";
         final NewsArticle actual = new NewsArticle();
-        Assert.assertNull(actual.getPostingHost());
+        Assertions.assertNull(actual.getPostingHost());
         actual.setPostingHost(expected);
-        Assert.assertEquals(expected, actual.getPostingHost());
+        Assertions.assertEquals(expected, actual.getPostingHost());
     }
 
     /**
@@ -126,9 +126,9 @@ public class NewsArticleTest {
     public void testGetReferences() {
         final String expected = "references";
         final NewsArticle actual = new NewsArticle();
-        Assert.assertNull(actual.getReferences());
+        Assertions.assertNull(actual.getReferences());
         actual.setReferences(expected);
-        Assert.assertEquals(expected, actual.getReferences());
+        Assertions.assertEquals(expected, actual.getReferences());
     }
 
     /**
@@ -139,7 +139,7 @@ public class NewsArticleTest {
         final NewsArticle test = new NewsArticle();
         test.setReferences("<effrl8$hmn$2@emma.aioe.org> <effupe$hr0$1@netlx020.civ.utwente.nl>");
         final List<String> actual = test.getReferencesList();
-        Assert.assertEquals(2, actual.size());
+        Assertions.assertEquals(2, actual.size());
     }
 
     /**
@@ -149,9 +149,9 @@ public class NewsArticleTest {
     public void testGetSubject() {
         final String expected = "subject";
         final NewsArticle actual = new NewsArticle();
-        Assert.assertNull(actual.getSubject());
+        Assertions.assertNull(actual.getSubject());
         actual.setSubject(expected);
-        Assert.assertEquals(expected, actual.getSubject());
+        Assertions.assertEquals(expected, actual.getSubject());
     }
 
     /**
@@ -160,9 +160,9 @@ public class NewsArticleTest {
     @Test
     public void testIsFullHeader() {
         final NewsArticle actual = new NewsArticle();
-        Assert.assertFalse(actual.isFullHeader());
+        Assertions.assertFalse(actual.isFullHeader());
         actual.setPostingHost("postingHost");
-        Assert.assertTrue(actual.isFullHeader());
+        Assertions.assertTrue(actual.isFullHeader());
     }
 
     /**
@@ -172,7 +172,7 @@ public class NewsArticleTest {
     public void testToString() {
         final NewsArticle test = new NewsArticle();
         test.setArticleNumber(100);
-        Assert.assertTrue(test.toString().contains("Number: 100"));
+        Assertions.assertTrue(test.toString().contains("Number: 100"));
     }
 
 }

--- a/src/test/java/uk/co/sleonard/unison/input/NewsClientImplTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/NewsClientImplTest.java
@@ -9,9 +9,9 @@ package uk.co.sleonard.unison.input;
 import org.apache.commons.net.nntp.NNTPClient;
 import org.apache.commons.net.nntp.NewsgroupInfo;
 import org.apache.commons.net.nntp.NewsgroupInfoFactory;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import uk.co.sleonard.unison.UNISoNException;
@@ -30,7 +30,7 @@ public class NewsClientImplTest {
     private NewsClient client;
     private NNTPClient mock;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.mock = Mockito.mock(NNTPClient.class);
         this.client = new NewsClientImpl(this.mock);
@@ -172,7 +172,7 @@ public class NewsClientImplTest {
         final int expected = 205;
         Mockito.when(this.mock.quit()).thenReturn(expected);
         final int actual = this.client.quit();
-        Assert.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
         Mockito.verify(this.mock).quit();
     }
 
@@ -188,7 +188,7 @@ public class NewsClientImplTest {
         final Reader reader = new StringReader("content");
         Mockito.when(this.mock.retrieveArticle(articleId)).thenReturn(reader);
         final Reader actual = this.client.retrieveArticle(articleId);
-        Assert.assertSame(reader, actual);
+        Assertions.assertSame(reader, actual);
         Mockito.verify(this.mock).retrieveArticle(articleId);
     }
 
@@ -205,7 +205,7 @@ public class NewsClientImplTest {
         final Reader header = new StringReader("header");
         Mockito.when(this.mock.retrieveArticleHeader(articleId)).thenReturn(header);
         final Reader actual = this.client.retrieveArticleHeader(articleId);
-        Assert.assertSame(header, actual);
+        Assertions.assertSame(header, actual);
         Mockito.verify(this.mock).retrieveArticleHeader(articleId);
     }
 
@@ -223,7 +223,7 @@ public class NewsClientImplTest {
         final BufferedReader reader = new BufferedReader(new StringReader("info"));
         Mockito.when(this.mock.retrieveArticleInfo(low, high)).thenReturn(reader);
         final BufferedReader actual = this.client.retrieveArticleInfo(low, high);
-        Assert.assertSame(reader, actual);
+        Assertions.assertSame(reader, actual);
         Mockito.verify(this.mock).retrieveArticleInfo(low, high);
     }
 

--- a/src/test/java/uk/co/sleonard/unison/input/NewsGroupReaderTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/NewsGroupReaderTest.java
@@ -6,9 +6,9 @@
  */
 package uk.co.sleonard.unison.input;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -29,7 +29,7 @@ public class NewsGroupReaderTest {
      * @throws Exception
      *             the exception
      */
-    @Before
+    @BeforeEach
     public void setUp() {
         this.newsGroup = new NewsGroupReader(new NewsClientImpl());
     }
@@ -43,10 +43,10 @@ public class NewsGroupReaderTest {
         final int expected = 1;
 
         actual = this.newsGroup.getMessagesSkipped();
-        Assert.assertEquals(0, actual);
+        Assertions.assertEquals(0, actual);
         this.newsGroup.incrementMessagesSkipped();
         actual = this.newsGroup.getMessagesSkipped();
-        Assert.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
     }
 
     /**
@@ -58,10 +58,10 @@ public class NewsGroupReaderTest {
         final int expected = 1;
 
         actual = this.newsGroup.getMessagesStored();
-        Assert.assertEquals(0, actual);
+        Assertions.assertEquals(0, actual);
         this.newsGroup.incrementMessagesStored();
         actual = this.newsGroup.getMessagesStored();
-        Assert.assertEquals(expected, actual);
+        Assertions.assertEquals(expected, actual);
     }
 
     /**
@@ -72,7 +72,7 @@ public class NewsGroupReaderTest {
         final NewsClient mockNewsClient = Mockito.mock(NewsClient.class);
         Mockito.when(mockNewsClient.getMessageCount()).thenReturn(10);
         this.newsGroup.setClient(mockNewsClient);
-        Assert.assertEquals(10, this.newsGroup.getNumberOfMessages());
+        Assertions.assertEquals(10, this.newsGroup.getNumberOfMessages());
     }
 
     /**
@@ -92,9 +92,9 @@ public class NewsGroupReaderTest {
     @Test
     public void testGetSetMessageCount() {
         final int expected = 5;
-        Assert.assertEquals(0, this.newsGroup.getMessageCount());
+        Assertions.assertEquals(0, this.newsGroup.getMessageCount());
         this.newsGroup.setMessageCount(expected);
-        Assert.assertEquals(expected, this.newsGroup.getMessageCount());
+        Assertions.assertEquals(expected, this.newsGroup.getMessageCount());
     }
 
     /**
@@ -104,7 +104,7 @@ public class NewsGroupReaderTest {
     public void testIncrementMessagesSkipped() {
         this.newsGroup.incrementMessagesSkipped();
         this.newsGroup.incrementMessagesSkipped();
-        Assert.assertEquals(2, this.newsGroup.getMessagesSkipped());
+        Assertions.assertEquals(2, this.newsGroup.getMessagesSkipped());
     }
 
     /**
@@ -114,7 +114,7 @@ public class NewsGroupReaderTest {
     public void testIncrementMessagesStored() {
         this.newsGroup.incrementMessagesStored();
         this.newsGroup.incrementMessagesStored();
-        Assert.assertEquals(2, this.newsGroup.getMessagesStored());
+        Assertions.assertEquals(2, this.newsGroup.getMessagesStored());
     }
 
     /**
@@ -123,6 +123,6 @@ public class NewsGroupReaderTest {
     @Test
     public void testIsConnected() {
         final boolean actual = this.newsGroup.isConnected();
-        Assert.assertFalse(actual);
+        Assertions.assertFalse(actual);
     }
 }

--- a/src/test/java/uk/co/sleonard/unison/input/SwingWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/SwingWorkerTest.java
@@ -1,13 +1,13 @@
 package uk.co.sleonard.unison.input;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link SwingWorker}.

--- a/src/test/java/uk/co/sleonard/unison/input/UNISoNCLI.java
+++ b/src/test/java/uk/co/sleonard/unison/input/UNISoNCLI.java
@@ -8,8 +8,8 @@ package uk.co.sleonard.unison.input;
 
 import lombok.extern.slf4j.Slf4j;
 import org.hsqldb.util.DatabaseManagerSwing;
-import org.junit.Assert;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import uk.co.sleonard.unison.UNISoNController;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest.DownloadMode;
@@ -28,7 +28,7 @@ import java.util.Set;
  * @since v1.0.0
  */
 @Slf4j
-@Ignore("Command line entry point - not a unit test")
+@Disabled("Command line entry point - not a unit test")
 public class UNISoNCLI {
 
     /**
@@ -144,7 +144,7 @@ public class UNISoNCLI {
         final UNISoNController instance = UNISoNController.getInstance();
         final Set<NewsGroup> listNewsgroups = instance.listNewsgroups(searchString, host,
                 instance.getNntpReader().getClient());
-        Assert.assertTrue(listNewsgroups.size() > 0);
+        Assertions.assertTrue(listNewsgroups.size() > 0);
     }
 
 

--- a/src/test/java/uk/co/sleonard/unison/input/UNISoNCLITest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/UNISoNCLITest.java
@@ -1,10 +1,10 @@
 package uk.co.sleonard.unison.input;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for {@link UNISoNCLI} argument parsing.

--- a/src/test/java/uk/co/sleonard/unison/output/ExportToCSVTest.java
+++ b/src/test/java/uk/co/sleonard/unison/output/ExportToCSVTest.java
@@ -6,9 +6,9 @@
  */
 package uk.co.sleonard.unison.output;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.co.sleonard.unison.UNISoNException;
 
 import javax.swing.*;
@@ -54,7 +54,7 @@ public class ExportToCSVTest {
      * @throws Exception
      *             the exception
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.export = new ExportToCSV();
 
@@ -77,13 +77,13 @@ public class ExportToCSVTest {
             final BufferedReader reader = new BufferedReader(fileReader);
             String currentLine = reader.readLine();
             while (currentLine != null) {
-                Assert.assertTrue(currentLine.contains("test"));
+                Assertions.assertTrue(currentLine.contains("test"));
                 currentLine = reader.readLine();
             }
             reader.close();
             file.delete();
         } catch (UNISoNException | IOException f) {
-            Assert.fail("ERROR: " + f.getMessage());
+            Assertions.fail("ERROR: " + f.getMessage());
         }
     }
 }

--- a/src/test/java/uk/co/sleonard/unison/output/PajekNetworkFileTest.java
+++ b/src/test/java/uk/co/sleonard/unison/output/PajekNetworkFileTest.java
@@ -6,9 +6,9 @@
  */
 package uk.co.sleonard.unison.output;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -51,7 +51,7 @@ public class PajekNetworkFileTest {
      *
      * @throws Exception the exception
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.file = new PajekNetworkFile();
     }
@@ -63,10 +63,10 @@ public class PajekNetworkFileTest {
     public void testAddRelationship() {
         final List<Relationship> links = new Vector<>();
         Relationship link = this.file.addRelationship("Alf", "Bob", links);
-        Assert.assertEquals(1, link.getValue());
+        Assertions.assertEquals(1, link.getValue());
         link = this.file.addRelationship("Alf", "Bob", links);
-        Assert.assertEquals(2, link.getValue());
-        Assert.assertEquals(1, links.size());
+        Assertions.assertEquals(2, link.getValue());
+        Assertions.assertEquals(1, links.size());
     }
 
     /**
@@ -76,7 +76,7 @@ public class PajekNetworkFileTest {
     public void testCreateDirectedLinks() {
         final Vector<Vector> nodePairs = this.generateNodePairs();
         this.file.createDirectedLinks(nodePairs);
-        Assert.assertEquals(2, nodePairs.size());
+        Assertions.assertEquals(2, nodePairs.size());
     }
 
     /**
@@ -86,7 +86,7 @@ public class PajekNetworkFileTest {
     public void testGetFilename() {
         final String expected = "UnitTest.net";
         this.testSaveToFile();
-        Assert.assertEquals(expected, this.file.getFilename());
+        Assertions.assertEquals(expected, this.file.getFilename());
     }
 
     /**
@@ -95,7 +95,7 @@ public class PajekNetworkFileTest {
     @Test
     public void testGetFileSuffix() {
         final String expected = ".net";
-        Assert.assertEquals(expected, this.file.getFileSuffix());
+        Assertions.assertEquals(expected, this.file.getFileSuffix());
     }
 
     /**
@@ -122,9 +122,9 @@ public class PajekNetworkFileTest {
         final Vector<Vector> nodePairs = this.generateNodePairs();
         this.file.createDirectedLinks(nodePairs);
         this.file.writeData(new PrintStream(outContent));
-        Assert.assertTrue(outContent.toString().contains("*Vertices"));
+        Assertions.assertTrue(outContent.toString().contains("*Vertices"));
         this.file.writeData(new PrintStream(outContent));
-        Assert.assertTrue(outContent.toString().contains("*Arcs"));
+        Assertions.assertTrue(outContent.toString().contains("*Arcs"));
 
     }
 

--- a/src/test/java/uk/co/sleonard/unison/output/RelationshipTest.java
+++ b/src/test/java/uk/co/sleonard/unison/output/RelationshipTest.java
@@ -6,9 +6,9 @@
  */
 package uk.co.sleonard.unison.output;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * The Class RelationshipTest.
@@ -23,7 +23,7 @@ public class RelationshipTest {
      *
      * @throws Exception the exception
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
     }
 
@@ -36,9 +36,9 @@ public class RelationshipTest {
         final Relationship r2 = new Relationship(10, 10);
         final Relationship r3 = new Relationship(10, 11);
 
-        Assert.assertEquals(r1, r2);
-        Assert.assertEquals(r2, r1);
-        Assert.assertNotEquals(r1, r3);
+        Assertions.assertEquals(r1, r2);
+        Assertions.assertEquals(r2, r1);
+        Assertions.assertNotEquals(r1, r3);
     }
 
     /**
@@ -48,7 +48,7 @@ public class RelationshipTest {
     public void testGetOwner() {
         final int expected = 5;
         final Relationship actual = new Relationship(5, 0);
-        Assert.assertEquals(expected, actual.getOwner());
+        Assertions.assertEquals(expected, actual.getOwner());
     }
 
     /**
@@ -58,7 +58,7 @@ public class RelationshipTest {
     public void testGetTarget() {
         final int expected = 3;
         final Relationship actual = new Relationship(0, 3);
-        Assert.assertEquals(expected, actual.getTarget());
+        Assertions.assertEquals(expected, actual.getTarget());
     }
 
     /**
@@ -68,7 +68,7 @@ public class RelationshipTest {
     public void testGetValue() {
         final int expected = 1;
         final Relationship actual = new Relationship(0, 0);
-        Assert.assertEquals(expected, actual.getValue());
+        Assertions.assertEquals(expected, actual.getValue());
     }
 
     /**
@@ -78,9 +78,9 @@ public class RelationshipTest {
     public void testHashCode() {
         final Relationship r1 = new Relationship(10, 20);
         final Relationship r2 = new Relationship(10, 20);
-        Assert.assertEquals(r1.hashCode(), r2.hashCode());
+        Assertions.assertEquals(r1.hashCode(), r2.hashCode());
         r2.incrementValue();
-        Assert.assertNotEquals(r1.hashCode(), r2.hashCode());
+        Assertions.assertNotEquals(r1.hashCode(), r2.hashCode());
     }
 
     /**
@@ -92,7 +92,7 @@ public class RelationshipTest {
         final Relationship actual = new Relationship(0, 0);
         actual.incrementValue();
         actual.incrementValue();
-        Assert.assertEquals(expected, actual.getValue());
+        Assertions.assertEquals(expected, actual.getValue());
     }
 
     /**
@@ -102,10 +102,10 @@ public class RelationshipTest {
     public void testToString() {
         String expected = "Relationship(owner=1, target=0, value=1)";
         final Relationship actual = new Relationship(1, 0);
-        Assert.assertEquals(expected, actual.toString());
+        Assertions.assertEquals(expected, actual.toString());
         actual.incrementValue();
         expected = "Relationship(owner=1, target=0, value=2)";
-        Assert.assertEquals(expected, actual.toString());
+        Assertions.assertEquals(expected, actual.toString());
     }
 
 }

--- a/src/test/java/uk/co/sleonard/unison/utils/DownloaderImplTest.java
+++ b/src/test/java/uk/co/sleonard/unison/utils/DownloaderImplTest.java
@@ -1,11 +1,8 @@
 package uk.co.sleonard.unison.utils;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.datahandling.HibernateHelper;
 import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest.DownloadMode;
@@ -19,8 +16,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 /**
  * Tests for {@link DownloaderImpl}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(FullDownloadWorker.class)
 public class DownloaderImplTest {
 
     /**
@@ -34,15 +29,14 @@ public class DownloaderImplTest {
         NewsGroupReader reader = Mockito.mock(NewsGroupReader.class);
         HibernateHelper helper = Mockito.mock(HibernateHelper.class);
 
-        PowerMockito.mockStatic(FullDownloadWorker.class);
+        try (MockedStatic<FullDownloadWorker> mocked = Mockito.mockStatic(FullDownloadWorker.class)) {
+            DownloaderImpl downloader = new DownloaderImpl(nntpHost, queue, newsClient, reader, helper);
+            String usenetId = "<123>";
+            DownloadMode mode = DownloadMode.ALL;
 
-        DownloaderImpl downloader = new DownloaderImpl(nntpHost, queue, newsClient, reader, helper);
-        String usenetId = "<123>";
-        DownloadMode mode = DownloadMode.ALL;
+            downloader.addDownloadRequest(usenetId, mode);
 
-        downloader.addDownloadRequest(usenetId, mode);
-
-        PowerMockito.verifyStatic(FullDownloadWorker.class, Mockito.times(1));
-        FullDownloadWorker.addDownloadRequest(usenetId, mode, nntpHost, queue, newsClient, reader, helper);
+            mocked.verify(() -> FullDownloadWorker.addDownloadRequest(usenetId, mode, nntpHost, queue, newsClient, reader, helper), Mockito.times(1));
+        }
     }
 }

--- a/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
+++ b/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
@@ -1,6 +1,6 @@
 package uk.co.sleonard.unison.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.co.sleonard.unison.UNISoNException;
 
 import java.io.ByteArrayInputStream;
@@ -11,7 +11,7 @@ import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * The Class StringUtilsTest.

--- a/src/test/java/uk/co/sleonard/unison/utils/TreeNodeTest.java
+++ b/src/test/java/uk/co/sleonard/unison/utils/TreeNodeTest.java
@@ -1,8 +1,8 @@
 package uk.co.sleonard.unison.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * The Class TreeNodeTest.


### PR DESCRIPTION
## Summary
- Switch project dependencies to JUnit Jupiter and configure Surefire for JUnit 5
- Replace PowerMock usage with Mockito static mocking
- Update tests to use JUnit 5 annotations and assertions

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a8aeae608327a17032bceae3d466

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/327)
<!-- Reviewable:end -->
