### PR TITLE
Guard location update when creating user

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/datahandling/UserFactory.java
+++ b/src/main/java/uk/co/sleonard/unison/datahandling/UserFactory.java
@@ -30,7 +30,7 @@ public class UserFactory {
             location = this.createLocation(article, session, helper);
         }
         final UsenetUser poster = this.findOrCreateUsenetUser(article, session, gender, helper);
-        if ((null == poster.getLocation()) || !poster.getLocation().equals(location)) {
+        if (location != null && (poster.getLocation() == null || !poster.getLocation().equals(location))) {
             poster.setLocation(location);
             session.saveOrUpdate(poster);
         }


### PR DESCRIPTION
## Summary
- Avoid persisting UsenetUser when location is null or unchanged

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ab271d7883278007e8f93071d50c