### PR TITLE
Specify HSQLDB driver and dialect in test

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/datahandling/DAO/UsenetUserPersistenceTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/DAO/UsenetUserPersistenceTest.java
@@ -18,6 +18,8 @@ public class UsenetUserPersistenceTest {
     public void testPersistAndLoad() {
         Configuration cfg = new Configuration().configure();
         cfg.setProperty("hibernate.connection.url", "jdbc:hsqldb:mem:usenetuser;DB_CLOSE_DELAY=-1");
+        cfg.setProperty("hibernate.connection.driver_class", "org.hsqldb.jdbcDriver");
+        cfg.setProperty("hibernate.dialect", "org.hibernate.dialect.HSQLDialect");
         cfg.setProperty("hibernate.hbm2ddl.auto", "create-drop");
 
         try (SessionFactory sf = cfg.buildSessionFactory();


### PR DESCRIPTION
## Summary
- configure UsenetUserPersistenceTest to explicitly set HSQLDB JDBC driver and dialect when building Hibernate configuration

## Testing
- `mvn -q -e -Dtest=UsenetUserPersistenceTest test` *(fails: PluginResolutionException: could not transfer artifact: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ab23d1208327938b23f1c96cec2e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/332)
<!-- Reviewable:end -->
