### PR TITLE
refactor: remove reflection from user and location tests

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperFindOrCreateUsenetUserTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperFindOrCreateUsenetUserTest.java
@@ -5,15 +5,15 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.input.NewsArticle;
+import uk.co.sleonard.unison.datahandling.UserFactory;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * Tests for {@link HibernateHelper#findOrCreateUsenetUser(NewsArticle, Session, String)}.
+ * Tests for {@link UserFactory#createUsenetUser(NewsArticle, Session, uk.co.sleonard.unison.datahandling.DAO.Location, String, HibernateHelper)}
+ * throwing {@link UNISoNException} when the From field cannot be parsed.
  */
 public class HibernateHelperFindOrCreateUsenetUserTest {
 
@@ -22,18 +22,11 @@ public class HibernateHelperFindOrCreateUsenetUserTest {
         HibernateHelper helper = new HibernateHelper(null);
         Session session = Mockito.mock(Session.class);
         NewsArticle article = new NewsArticle("id", 1, new Date(), "", "subj", "", null, "alt.test",
-                "127.0.0.1");
+                null);
 
-        Method m = HibernateHelper.class.getDeclaredMethod("findOrCreateUsenetUser", NewsArticle.class,
-                Session.class, String.class);
-        m.setAccessible(true);
+        UserFactory userFactory = new UserFactory();
 
-        assertThrows(UNISoNException.class, () -> {
-            try {
-                m.invoke(helper, article, session, null);
-            } catch (InvocationTargetException e) {
-                throw e.getCause();
-            }
-        });
+        assertThrows(UNISoNException.class,
+                () -> userFactory.createUsenetUser(article, session, null, null, helper));
     }
 }

--- a/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperSetLocationTest.java
+++ b/src/test/java/uk/co/sleonard/unison/datahandling/HibernateHelperSetLocationTest.java
@@ -7,8 +7,8 @@ import org.mockito.Mockito;
 import uk.co.sleonard.unison.datahandling.DAO.Location;
 import uk.co.sleonard.unison.datahandling.DAO.UsenetUser;
 import uk.co.sleonard.unison.input.NewsArticle;
+import uk.co.sleonard.unison.datahandling.UserFactory;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Date;
 
@@ -30,9 +30,8 @@ public class HibernateHelperSetLocationTest {
 
         NewsArticle article = new NewsArticle("id", 1, new Date(), "name@example.com", "subject", "refs", "content", "group", null);
 
-        Method method = HibernateHelper.class.getDeclaredMethod("createUsenetUser", NewsArticle.class, Session.class, Location.class, String.class);
-        method.setAccessible(true);
-        method.invoke(helper, article, session, newLocation, null);
+        UserFactory userFactory = new UserFactory();
+        userFactory.createUsenetUser(article, session, newLocation, null, helper);
 
         Mockito.verify(poster, Mockito.times(1)).setLocation(newLocation);
     }


### PR DESCRIPTION
## Summary
- refactor tests to call UserFactory APIs instead of reflective HibernateHelper methods
- verify location updates using public factory behavior

## Testing
- `mvn -q test` *(fails: PluginResolutionException: could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:3.3.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ab22256c83279d385af41781757b