### PR TITLE
chore: switch static mocking to Mockito

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/UNISoNControllerListNewsgroupsTest.java
+++ b/src/test/java/uk/co/sleonard/unison/UNISoNControllerListNewsgroupsTest.java
@@ -51,6 +51,7 @@ class UNISoNControllerListNewsgroupsTest {
                 assertSame(expected, result);
                 assertEquals(host, controller.getNntpHost());
                 verify(client).listNewsGroups(group, host);
+                sessionManager.verify(() -> SessionManager.openSession(), Mockito.times(1));
             }
         }
     }

--- a/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
@@ -18,7 +18,7 @@ public class DataHibernatorPoolImplTest {
             DataHibernatorPool pool = new DataHibernatorPoolImpl();
             pool.stopAllDownloads();
 
-            mocked.verify(DataHibernatorWorker::stopDownload, Mockito.times(1));
+            mocked.verify(() -> DataHibernatorWorker.stopDownload(), Mockito.times(1));
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace DataHibernatorWorker static invocation with Mockito's MockedStatic + lambda verify
- verify SessionManager.openSession using MockedStatic.verify in controller tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ab2102b08327bf7d4e4487d1c04e