### PR TITLE
Specify surefire plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.2.5</version>
                 <configuration>
                     <includes>
                         <include>**/*Test.java</include>


### PR DESCRIPTION
## Summary
- explicitly set `maven-surefire-plugin` to version 3.2.5 to silence build-time warning

## Testing
- `mvn -q -Djava.net.preferIPv4Stack=true test` *(fails: PluginResolutionException for maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ab1d1d108327800486a87ef4faf7