### PR TITLE
Set DownloadMode.ALL before storing article info in test

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
@@ -219,6 +219,9 @@ public class HeaderDownloadWorkerTest {
         setField(this.worker, "endIndex", 600);
         setField(this.worker, "newsReader", reader);
 
+        // ensure complete article information is downloaded
+        this.worker.setMode(DownloadMode.ALL);
+
         this.worker.storeArticleInfo(queue);
 
         final ArgumentCaptor<Long> endCaptor = ArgumentCaptor.forClass(Long.class);


### PR DESCRIPTION
## Summary
- Ensure `HeaderDownloadWorkerTest` sets download mode to `ALL` before storing article info to avoid null pointer issues

## Testing
- `mvn -e -Dtest=uk.co.sleonard.unison.input.HeaderDownloadWorkerTest#testStoreArticleInfoDoesNotRequestBeyondEndIndex test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ab1bc6a4832794d4d1d86cc58eac