### PR TITLE
Add JetBrains annotations and improve null-safety

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,12 @@
             <version>${lombok.version}</version>
             <scope>compile</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>26.0.2</version>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/src/main/java/uk/co/sleonard/unison/output/ExportToCSV.java
+++ b/src/main/java/uk/co/sleonard/unison/output/ExportToCSV.java
@@ -6,6 +6,7 @@
  */
 package uk.co.sleonard.unison.output;
 
+import org.jetbrains.annotations.NotNull;
 import uk.co.sleonard.unison.UNISoNException;
 
 import javax.swing.*;
@@ -14,6 +15,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
+import java.util.Objects;
 import java.util.Vector;
 
 /**
@@ -43,9 +45,12 @@ public class ExportToCSV {
      * @param fieldNames the field names
      * @throws UNISoNException the UNI so n exception
      */
-    void exportTable(final String fileName, final JTable table, final Vector<String> fieldNames)
-            throws UNISoNException {
+    void exportTable(final @NotNull String fileName, final @NotNull JTable table,
+                     final @NotNull Vector<String> fieldNames) throws UNISoNException {
         try {
+            Objects.requireNonNull(fileName, "fileName");
+            Objects.requireNonNull(table, "table");
+            Objects.requireNonNull(fieldNames, "fieldNames");
             final File file = new File(fileName);
             if (file != null) {
 
@@ -92,8 +97,10 @@ public class ExportToCSV {
      * @throws UNISoNException the UNI so n exception
      */
     @SuppressWarnings("deprecation")
-    public void exportTableToCSV(final JTable table, final Vector<String> fieldNames)
+    public void exportTableToCSV(final @NotNull JTable table, final @NotNull Vector<String> fieldNames)
             throws UNISoNException {
+        Objects.requireNonNull(table, "table");
+        Objects.requireNonNull(fieldNames, "fieldNames");
         final FileDialog file = new FileDialog(new JFrame(), "Save CSV Network File",
                 FileDialog.SAVE);
         final String CSV_FILE_SUFFIX = ".csv";
@@ -126,11 +133,12 @@ public class ExportToCSV {
      * @param data the data
      * @return the string
      */
-    private String extractCommas(final String dataInput) {
-        if (dataInput.indexOf(',') > -1) {
-            return dataInput.replaceAll(",", ";");
+    private @NotNull String extractCommas(final @NotNull String dataInput) {
+        final String data = Objects.requireNonNull(dataInput, "dataInput");
+        if (data.indexOf(',') > -1) {
+            return data.replaceAll(",", ";");
         }
-        return dataInput;
+        return data;
     }
 
 }

--- a/src/main/java/uk/co/sleonard/unison/utils/Downloader.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/Downloader.java
@@ -6,6 +6,7 @@
  */
 package uk.co.sleonard.unison.utils;
 
+import org.jetbrains.annotations.NotNull;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest.DownloadMode;
 
@@ -18,6 +19,6 @@ public interface Downloader {
      *             {@link DownloadMode#BASIC}, {@link DownloadMode#HEADERS} or {@link DownloadMode#ALL}
      * @throws UNISoNException if the request cannot be queued or the mode is unsupported
      */
-    void addDownloadRequest(final String usenetID, final DownloadMode mode) throws UNISoNException;
+    void addDownloadRequest(@NotNull String usenetID, @NotNull DownloadMode mode) throws UNISoNException;
 
 }

--- a/src/main/java/uk/co/sleonard/unison/utils/DownloaderImpl.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/DownloaderImpl.java
@@ -7,13 +7,14 @@
 package uk.co.sleonard.unison.utils;
 
 import uk.co.sleonard.unison.UNISoNController;
-import org.hibernate.Session;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest.DownloadMode;
 import uk.co.sleonard.unison.datahandling.HibernateHelper;
 import uk.co.sleonard.unison.input.*;
 
+import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
+import org.jetbrains.annotations.NotNull;
 
 public class DownloaderImpl implements Downloader {
 
@@ -30,19 +31,23 @@ public class DownloaderImpl implements Downloader {
                 UNISoNController.getInstance().getHelper());
     }
 
-    public DownloaderImpl(final String nntpHost, final LinkedBlockingQueue<NewsArticle> queue1,
-                          final NewsClient newsClient1, final NewsGroupReader reader,
-                          final HibernateHelper helper2) {
-        this.nntpHost = nntpHost;
-        this.queue = queue1;
-        this.newsClient = newsClient1;
-        this.nntpReader = reader;
-        this.helper = helper2;
+    public DownloaderImpl(final @NotNull String nntpHost,
+                          final @NotNull LinkedBlockingQueue<NewsArticle> queue1,
+                          final @NotNull NewsClient newsClient1,
+                          final @NotNull NewsGroupReader reader,
+                          final @NotNull HibernateHelper helper2) {
+        this.nntpHost = Objects.requireNonNull(nntpHost, "nntpHost");
+        this.queue = Objects.requireNonNull(queue1, "queue");
+        this.newsClient = Objects.requireNonNull(newsClient1, "newsClient");
+        this.nntpReader = Objects.requireNonNull(reader, "reader");
+        this.helper = Objects.requireNonNull(helper2, "helper");
     }
 
     @Override
-    public void addDownloadRequest(final String usenetID, final DownloadMode mode) throws UNISoNException {
-        FullDownloadWorker.addDownloadRequest(usenetID, mode, this.nntpHost, this.queue,
+    public void addDownloadRequest(final @NotNull String usenetID, final @NotNull DownloadMode mode)
+            throws UNISoNException {
+        FullDownloadWorker.addDownloadRequest(Objects.requireNonNull(usenetID, "usenetID"),
+                Objects.requireNonNull(mode, "mode"), this.nntpHost, this.queue,
                 this.newsClient, this.nntpReader, this.helper);
     }
 

--- a/src/main/java/uk/co/sleonard/unison/utils/TreeNode.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/TreeNode.java
@@ -3,6 +3,9 @@ package uk.co.sleonard.unison.utils;
 import javax.swing.tree.DefaultMutableTreeNode;
 import lombok.Getter;
 import lombok.Setter;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
 
 /**
  * Represents a node in the application's GUI hierarchy.
@@ -28,9 +31,9 @@ public class TreeNode extends DefaultMutableTreeNode {
      * @param childObject the child object
      * @param name        the name
      */
-    public TreeNode(final Object childObject, final String name) {
-        super(childObject);
-        this.nodeName = name;
+    public TreeNode(final @NotNull Object childObject, final @NotNull String name) {
+        super(Objects.requireNonNull(childObject, "childObject"));
+        this.nodeName = Objects.requireNonNull(name, "name");
     }
 
     /*
@@ -39,7 +42,7 @@ public class TreeNode extends DefaultMutableTreeNode {
      * @see javax.swing.tree.DefaultMutableTreeNode#toString()
      */
     @Override
-    public String toString() {
+    public @NotNull String toString() {
         return this.nodeName;
     }
 }

--- a/src/test/java/uk/co/sleonard/unison/output/ExportToCSVTest.java
+++ b/src/test/java/uk/co/sleonard/unison/output/ExportToCSVTest.java
@@ -17,7 +17,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Vector;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The Class ExportToCSV.
@@ -36,13 +38,13 @@ public class ExportToCSVTest {
      *
      * @return JTable filled.
      */
-    private JTable generateJTableToTest() {
-        DefaultTableModel model;
-        model = new DefaultTableModel();
+    private @NotNull JTable generateJTableToTest(@NotNull Vector<String> columnNames) {
+        Objects.requireNonNull(columnNames, "columnNames");
+        final DefaultTableModel model = new DefaultTableModel();
         final JTable jTable = new JTable(model);
-        model.addColumn(null);
-        model.addColumn(null);
-        model.addColumn(null);
+        for (String column : columnNames) {
+            model.addColumn(column);
+        }
         model.addRow(new Object[]{"element1", "element2", "test"});
         model.addRow(new Object[]{"element3", "element4", "test"});
         return jTable;
@@ -71,7 +73,8 @@ public class ExportToCSVTest {
         fieldNames.addElement("column2");
         fieldNames.addElement("test");
         try {
-            this.export.exportTable(archiveName, this.generateJTableToTest(), fieldNames);
+            final JTable table = this.generateJTableToTest(fieldNames);
+            this.export.exportTable(archiveName, table, fieldNames);
             final File file = new File(archiveName);
             final FileReader fileReader = new FileReader(file.getCanonicalPath());
             final BufferedReader reader = new BufferedReader(fileReader);


### PR DESCRIPTION
## Summary
- add JetBrains annotations dependency
- annotate parameters and return types with @NotNull
- use Objects.requireNonNull for defensive checks and update tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a8b476f0832794a06dde552b4fa8