### PR TITLE
Add JaCoCo coverage check and configure Surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <jakarta.mail.version>2.1.3</jakarta.mail.version>
         <h2.version>2.2.224</h2.version>
         <it.includes></it.includes>
+        <jacoco.version>0.8.11</jacoco.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -149,10 +150,56 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>${argLine}</argLine>
                     <includes>
                         <include>**/*Test.java</include>
                         <include>${it.includes}</include>
                     </includes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>uk/co/sleonard/unison/gui/*.class</exclude>
+                        <exclude>uk/co/sleonard/unison/gui/generated/*.class</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -402,38 +449,6 @@
         </developer>
     </developers><!-- to get to sona type and onto maven central -->
     <profiles>
-        <profile>
-            <id>coverage</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>${jacoco.version}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>report</id>
-                                <phase>test</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <excludes>
-                                <exclude>uk/co/sleonard/unison/gui/*.class</exclude>
-                                <exclude>uk/co/sleonard/unison/gui/generated/*.class</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>release</id>
             <build>


### PR DESCRIPTION
## Summary
- add JaCoCo plugin with coverage reporting and 80% line coverage check
- configure Surefire to run tests with the JaCoCo agent
- define JaCoCo version property and remove obsolete coverage profile

## Testing
- `mvn -q verify` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a8af98ec8327bab68ea696940449