### PR TITLE
Use existing controller in MessageStoreViewer

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewer.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewer.java
@@ -1078,7 +1078,7 @@ class MessageStoreViewer extends javax.swing.JPanel implements DataChangeListene
             for (final GUIItem<ResultRow> row : selected) {
                 countries.add((String) row.getObject().getKey());
             }
-            UNISoNController.getInstance().getFilter().setSelectedCountries(countries);
+            this.controller.getFilter().setSelectedCountries(countries);
             this.refreshTopGroups();
         }
     }// GEN-LAST:event_topCountriesListValueChanged
@@ -1133,7 +1133,7 @@ class MessageStoreViewer extends javax.swing.JPanel implements DataChangeListene
             for (final GUIItem<ResultRow> row : selected) {
                 posters.add((String) row.getObject().getKey());
             }
-            UNISoNController.getInstance().getFilter().setSelectedPosters(posters);
+            this.controller.getFilter().setSelectedPosters(posters);
             this.refreshMessagePane();
         }
     }// GEN-LAST:event_topPostersListValueChanged


### PR DESCRIPTION
## Summary
- Use the injected controller rather than the singleton in MessageStoreViewer's top list handlers

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.11 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b8326edc832793107f952e95d8a2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/343)
<!-- Reviewable:end -->
