### PR TITLE
Fix tests failing due to JAXB and Mockito

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,14 +36,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>4.0.2</version>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.3</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>4.0.5</version>
+                <version>2.3.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -366,10 +366,10 @@
             <version>2.0.2</version>
         </dependency>
 
-        <!-- Jakarta XML Binding -->
+        <!-- JAXB API and runtime for Hibernate configuration -->
         <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
         </dependency>
 
         <dependency>

--- a/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
+++ b/src/test/java/uk/co/sleonard/unison/utils/StringUtilsTest.java
@@ -206,17 +206,17 @@ public class StringUtilsTest {
     /**
      * Test stringToDate with String length 8 throw UNISoNException
      */
-    @Test()
-    public void testStringToDateExceptionLength8() throws UNISoNException {
-        StringUtils.stringToDate("xxxxxxxx");
+    @Test
+    public void testStringToDateExceptionLength8() {
+        assertThrows(UNISoNException.class, () -> StringUtils.stringToDate("xxxxxxxx"));
     }
 
     /**
      * Test stringToDate with String length 10 throw UNISoNException
      */
-    @Test()
-    public void testStringToDateExceptionLength10() throws UNISoNException {
-        StringUtils.stringToDate("xx/xx/xxxx");
+    @Test
+    public void testStringToDateExceptionLength10() {
+        assertThrows(UNISoNException.class, () -> StringUtils.stringToDate("xx/xx/xxxx"));
     }
 
     /**

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass


### PR DESCRIPTION
## Summary
- Switch to javax JAXB dependencies so Hibernate config can be parsed on Java 21
- Force Mockito to use subclass mock maker to avoid instrumentation issues
- Adjust StringUtils tests to expect UNISoNException

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.11 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fd0fe3dc8327a907f47a687f76ed