### PR TITLE
Allow TreeNode to accept null children

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/utils/TreeNode.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/TreeNode.java
@@ -31,8 +31,8 @@ public class TreeNode extends DefaultMutableTreeNode {
      * @param childObject the child object
      * @param name        the name
      */
-    public TreeNode(final @NotNull Object childObject, final @NotNull String name) {
-        super(Objects.requireNonNull(childObject, "childObject"));
+    public TreeNode(final Object childObject, final @NotNull String name) {
+        super(childObject);
         this.nodeName = Objects.requireNonNull(name, "name");
     }
 

--- a/src/test/java/uk/co/sleonard/unison/utils/TreeNodeTest.java
+++ b/src/test/java/uk/co/sleonard/unison/utils/TreeNodeTest.java
@@ -33,4 +33,10 @@ public class TreeNodeTest {
         assertEquals(expected, actual.toString());
 
     }
+
+    @Test
+    public void testNullChildObject() {
+        TreeNode actual = new TreeNode(null, "root");
+        assertEquals("root", actual.toString());
+    }
 }


### PR DESCRIPTION
## Summary
- let TreeNode accept `null` child objects
- add test for null child handling

## Testing
- `mvn -q -Djacoco.skip=true test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.11 or one of its dependencies could not be resolved: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.11 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_68a209700af083278e3ec39638b07e73