### PR TITLE
Ensure header download thread processes requests

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/input/HeaderDownloadWorker.java
+++ b/src/main/java/uk/co/sleonard/unison/input/HeaderDownloadWorker.java
@@ -63,12 +63,12 @@ public class HeaderDownloadWorker extends SwingWorker {
     /**
      * The downloading.
      */
-    private boolean downloading = false;
+    private volatile boolean downloading = false;
 
     /**
      * The running.
      */
-    private boolean running = true;
+    private volatile boolean running = true;
 
     /**
      * The log tally.

--- a/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
@@ -236,6 +236,20 @@ public class HeaderDownloadWorkerTest {
         }
     }
 
+    @Test
+    void testResumeTriggersStoreArticleInfo() throws Exception {
+        final HeaderDownloadWorker spyWorker = Mockito.spy(
+                new HeaderDownloadWorker(new LinkedBlockingQueue<>(),
+                        Mockito.mock(Downloader.class)));
+        Mockito.doReturn(true).when(spyWorker).storeArticleInfo(Mockito.any());
+
+        spyWorker.initialise();
+        spyWorker.resume();
+
+        Mockito.verify(spyWorker, Mockito.timeout(1000)).storeArticleInfo(Mockito.any());
+        spyWorker.fullstop();
+    }
+
     private void setField(final Object target, final String fieldName, final Object value) throws Exception {
         final Field field = target.getClass().getDeclaredField(fieldName);
         field.setAccessible(true);


### PR DESCRIPTION
## Summary
- make header download worker's control flags `volatile` so downloads start reliably
- add unit test verifying worker reacts to resume calls

## Testing
- `mvn -q -Djacoco.skip=true test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.11 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a228e461f88327b0aed69367d3dcc8

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/347)
<!-- Reviewable:end -->
