### PR TITLE
Add trace logging for message downloads

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/utils/DownloaderImpl.java
+++ b/src/main/java/uk/co/sleonard/unison/utils/DownloaderImpl.java
@@ -6,6 +6,7 @@
  */
 package uk.co.sleonard.unison.utils;
 
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import uk.co.sleonard.unison.UNISoNController;
 import uk.co.sleonard.unison.UNISoNException;
@@ -19,6 +20,7 @@ import uk.co.sleonard.unison.input.NewsGroupReader;
 import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
 
+@Slf4j
 public class DownloaderImpl implements Downloader {
 
     private final String nntpHost;
@@ -45,6 +47,7 @@ public class DownloaderImpl implements Downloader {
     @Override
     public void addDownloadRequest(final @NotNull String usenetID, final @NotNull DownloadMode mode)
             throws UNISoNException {
+        log.trace("Received request to download {} in mode {}", usenetID, mode);
         FullDownloadWorker.addDownloadRequest(Objects.requireNonNull(usenetID, "usenetID"),
                 Objects.requireNonNull(mode, "mode"), this.nntpHost, this.queue,
                 this.newsClient, this.nntpReader, this.helper, this.controller);


### PR DESCRIPTION
## Summary
- add trace-level logging when queueing and processing downloads
- log retrieval steps for headers and full messages
- instrument `DownloaderImpl` to trace incoming download requests

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.11 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a22f19b5808327b1712ff8728c7a68