### PR TITLE
Ensure sequential header downloads

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/UNISoNController.java
+++ b/src/main/java/uk/co/sleonard/unison/UNISoNController.java
@@ -322,11 +322,15 @@ public class UNISoNController {
                         mode,
                         fromDate1,
                         toDate1);
-                log.debug("Initialised header downloader for {}", group.getName());
+                headerDownloader2.awaitCompletion();
+                log.debug("Completed header download for {}", group.getName());
             } catch (final IOException e) {
                 e.printStackTrace();
                 throw new UNISoNException(
                         "Error downloading messages. Check your internet connection: ", e);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new UNISoNException("Header download interrupted", e);
             }
         }
     }


### PR DESCRIPTION
## Summary
- synchronize header downloads using a CountDownLatch in `HeaderDownloadWorker`
- block `UNISoNController.quickDownload` until each header download completes
- add unit test covering the new completion signal

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.11 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a2404d21c88327b11af63798399cde

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/350)
<!-- Reviewable:end -->
