### PR TITLE
Fix newsgroup handling in HeaderDownloadWorker

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/input/HeaderDownloadWorker.java
+++ b/src/main/java/uk/co/sleonard/unison/input/HeaderDownloadWorker.java
@@ -105,6 +105,11 @@ public class HeaderDownloadWorker extends SwingWorker {
      */
     private DownloadMode mode;
 
+    /**
+     * The newsgroup being processed.
+     */
+    private String newsgroup;
+
     private final LinkedBlockingQueue<NewsArticle> queue;
 
     private final Downloader downloader;
@@ -249,6 +254,7 @@ public class HeaderDownloadWorker extends SwingWorker {
         this.startIndex = startIndex1;
         this.endIndex = endIndex1;
         this.newsReader = reader;
+        this.newsgroup = newsgroup1;
         this.fromDate = from;
         this.toDate = to;
 
@@ -328,7 +334,7 @@ public class HeaderDownloadWorker extends SwingWorker {
 
         if (this.inDateRange(this.fromDate, this.toDate, date)) {
             queue1.add(new NewsArticle(articleId, articleNumber, date, from, subject, references,
-                    references));
+                    this.newsgroup));
             this.kept++;
             if (!this.mode.equals(DownloadMode.BASIC)) {
                 this.downloader.addDownloadRequest(articleId, this.mode);

--- a/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
@@ -170,6 +170,22 @@ class HeaderDownloadWorkerTest {
         }
     }
 
+    @Test
+    void testProcessMessageSetsNewsgroup() throws Exception {
+        final LinkedBlockingQueue<NewsArticle> queue = new LinkedBlockingQueue<>();
+        final NewsClient nc = Mockito.mock(NewsClient.class);
+        final NewsGroupReader ngr = new NewsGroupReader(nc, Mockito.mock(UNISoNController.class));
+
+        this.worker.initialise(ngr, 0, 1, "server", "alt.test", DownloadMode.BASIC, null, null);
+
+        final String line = "1\tSubject\tfrom@example.com\t2016-04-01\t<id>\t<ref>";
+        this.worker.processMessage(queue, line);
+
+        final NewsArticle article = queue.poll();
+        Assertions.assertNotNull(article);
+        Assertions.assertEquals("alt.test", article.getNewsgroups());
+    }
+
     /**
      * Test construct
      *


### PR DESCRIPTION
## Summary
- Track selected newsgroup in `HeaderDownloadWorker`
- Ensure `NewsArticle` instances use the worker's newsgroup
- Add unit test verifying articles capture correct newsgroup

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.11)*

------
https://chatgpt.com/codex/tasks/task_e_68a24a1ac49083279351c33081c5584a

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/351)
<!-- Reviewable:end -->
