### PR TITLE
Store newsgroup for header downloads

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/input/HeaderDownloadWorker.java
+++ b/src/main/java/uk/co/sleonard/unison/input/HeaderDownloadWorker.java
@@ -47,6 +47,11 @@ public class HeaderDownloadWorker extends SwingWorker {
     private NewsGroupReader newsReader = null;
 
     /**
+     * The newsgroup.
+     */
+    private String newsgroup;
+
+    /**
      * The start index.
      */
     private int startIndex;
@@ -249,6 +254,7 @@ public class HeaderDownloadWorker extends SwingWorker {
         this.startIndex = startIndex1;
         this.endIndex = endIndex1;
         this.newsReader = reader;
+        this.newsgroup = newsgroup1;
         this.fromDate = from;
         this.toDate = to;
 
@@ -328,7 +334,7 @@ public class HeaderDownloadWorker extends SwingWorker {
 
         if (this.inDateRange(this.fromDate, this.toDate, date)) {
             queue1.add(new NewsArticle(articleId, articleNumber, date, from, subject, references,
-                    references));
+                    this.newsgroup));
             this.kept++;
             if (!this.mode.equals(DownloadMode.BASIC)) {
                 this.downloader.addDownloadRequest(articleId, this.mode);

--- a/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
@@ -170,6 +170,22 @@ class HeaderDownloadWorkerTest {
         }
     }
 
+    @Test
+    void testProcessMessageUsesNewsgroup() throws UNISoNException {
+        final LinkedBlockingQueue<NewsArticle> queue = new LinkedBlockingQueue<>();
+        final NewsClient nc = Mockito.mock(NewsClient.class);
+        final NewsGroupReader ngr = new NewsGroupReader(nc, Mockito.mock(UNISoNController.class));
+        this.worker.initialise(ngr, 0, 1, "server", "test.group", DownloadMode.BASIC, null, null);
+
+        final String line =
+                "1\tSubject\tsender@email.com\t2016-04-01\t1234\t123@email.com";
+        this.worker.processMessage(queue, line);
+
+        final NewsArticle article = queue.poll();
+        Assertions.assertNotNull(article);
+        Assertions.assertEquals("test.group", article.getNewsgroups());
+    }
+
     /**
      * Test construct
      *


### PR DESCRIPTION
## Summary
- keep track of the current newsgroup in `HeaderDownloadWorker`
- use stored newsgroup when creating `NewsArticle`
- test that `processMessage` preserves newsgroup information

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.11)*
- `mvn -q -Djacoco.skip=true test` *(fails: Could not transfer artifact org.jacoco:jacoco-maven-plugin:pom:0.8.11)*

------
https://chatgpt.com/codex/tasks/task_e_68a249fe03ac832796cc3efb1440c672

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/352)
<!-- Reviewable:end -->
