### PR TITLE
refactor: improve fullStop test synchronization

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
@@ -57,15 +57,18 @@ public class HeaderDownloadWorkerTest {
      * Test fullStop
      */
     @Test
-    public void testFullStop() {
-        System.out.println("Wait 2 secs and stop");
-        try {
-            Thread.sleep(2000);
-        } catch (final InterruptedException e) {
-            e.printStackTrace();
-        }
-        System.out.println("Stop");
-        this.worker.fullStop();
+    public void testFullStop() throws InterruptedException {
+        this.worker.initialise();
+        this.worker.resume();
+        Assert.assertTrue(this.worker.isDownloading());
+        final java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
+        new Thread(() -> {
+            this.worker.fullStop();
+            latch.countDown();
+        }).start();
+        Assert.assertTrue("fullStop did not complete in time",
+                latch.await(1, java.util.concurrent.TimeUnit.SECONDS));
+        Assert.assertFalse(this.worker.isDownloading());
     }
 
     /**


### PR DESCRIPTION
## Summary
- replace fixed `Thread.sleep` delay with `CountDownLatch` for synchronization in `HeaderDownloadWorkerTest`
- ensure `fullStop` stops the worker and removes any console output

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a24fc6da3c83278ed0ee449a08d20b

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/353)
<!-- Reviewable:end -->
