### PR TITLE
Add failing connect test for FullDownloadWorker

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/input/FullDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/FullDownloadWorkerTest.java
@@ -171,8 +171,18 @@ public class FullDownloadWorkerTest {
 
     @Test
     public void testFailToConnect() throws Exception {
+        Mockito.reset(this.newsClient);
         Mockito.doThrow(new IOException("Failed to connect")).when(this.newsClient)
                 .connect(ArgumentMatchers.anyString());
+        Mockito.when(this.newsClient.retrieveArticle(ArgumentMatchers.anyString()))
+                .thenAnswer(invocation -> {
+                    this.newsClient.connect("host");
+                    return new StringReader("");
+                });
+        final DownloadRequest request = new DownloadRequest("<id>", DownloadMode.ALL);
+        Assert.assertThrows(IOException.class,
+                () -> this.worker.downloadFullMessage(request));
+        Mockito.verify(this.newsClient).connect(ArgumentMatchers.anyString());
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure FullDownloadWorker test triggers news client connect and verifies IOException propagation

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a24fc1faf88327a9d63b5a7a1fab86