### PR TITLE
Centralise session handling for download workers

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/UNISoNController.java
+++ b/src/main/java/uk/co/sleonard/unison/UNISoNController.java
@@ -29,6 +29,11 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * The Class UNISoNController.
+ * <p>
+ * Manages high level application state including a long-lived Hibernate
+ * {@link Session} used for filtering and analysis. The session is created on
+ * construction and should be closed by calling {@link #close()} when the
+ * controller is no longer required.
  *
  * @author Stephen <github@leonarduk.com>
  * @since v1.0.0
@@ -256,13 +261,21 @@ public class UNISoNController {
      * @return the queue
      */
     public LinkedBlockingQueue<NewsArticle> getQueue() {
-        DataHibernatorWorker.startHibernators(this.getNntpReader(), this.helper, this.messageQueue,
-                this.session);
+        DataHibernatorWorker.startHibernators(this.getNntpReader(), this.helper, this.messageQueue);
         return this.messageQueue;
     }
 
     public Session getSession() {
         return this.session;
+    }
+
+    /**
+     * Close resources held by this controller including the long-lived Hibernate session.
+     */
+    public void close() {
+        if (this.session != null && this.session.isOpen()) {
+            this.session.close();
+        }
     }
 
     /**

--- a/src/main/java/uk/co/sleonard/unison/datahandling/SessionManager.java
+++ b/src/main/java/uk/co/sleonard/unison/datahandling/SessionManager.java
@@ -9,7 +9,9 @@ import org.hibernate.cfg.Configuration;
  * Utility class responsible for creating and providing Hibernate {@link Session}
  * instances. The configuration is read from the standard Hibernate
  * configuration file on first use and the {@link SessionFactory} is cached for
- * subsequent calls.
+ * subsequent calls. All session creation is centralised here to avoid
+ * scattering configuration throughout the codebase. Callers are responsible for
+ * closing sessions when finished to prevent resource leaks.
  */
 @Slf4j
 public final class SessionManager {

--- a/src/main/java/uk/co/sleonard/unison/input/FullDownloadWorker.java
+++ b/src/main/java/uk/co/sleonard/unison/input/FullDownloadWorker.java
@@ -8,13 +8,11 @@ package uk.co.sleonard.unison.input;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.net.MalformedServerReplyException;
-import org.hibernate.Session;
 import uk.co.sleonard.unison.UNISoNController;
 import uk.co.sleonard.unison.UNISoNException;
 import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest;
 import uk.co.sleonard.unison.datahandling.DAO.DownloadRequest.DownloadMode;
 import uk.co.sleonard.unison.datahandling.HibernateHelper;
-import uk.co.sleonard.unison.datahandling.SessionManager;
 import uk.co.sleonard.unison.utils.StringUtils;
 
 import java.io.BufferedReader;
@@ -76,7 +74,6 @@ public class FullDownloadWorker extends SwingWorker {
                                                        final LinkedBlockingQueue<NewsArticle> queue, final NewsClient newsClient,
                                                        final NewsGroupReader nntpReader, final HibernateHelper helper,
                                                        final UNISoNController controller) throws UNISoNException {
-        Session session = SessionManager.openSession();
         final DownloadRequest request = new DownloadRequest(usenetID, mode);
         log.trace("Queueing download request {} in mode {}", usenetID, mode);
 
@@ -85,7 +82,7 @@ public class FullDownloadWorker extends SwingWorker {
         if (FullDownloadWorker.downloaders.isEmpty()) {
             FullDownloadWorker.startDownloaders(1, nntpHost, queue, newsClient, controller);
         }
-        DataHibernatorWorker.startHibernators(nntpReader, helper, queue, session);
+        DataHibernatorWorker.startHibernators(nntpReader, helper, queue);
     }
 
     /**

--- a/src/test/java/uk/co/sleonard/unison/input/DataHibernatorWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/DataHibernatorWorkerTest.java
@@ -46,10 +46,9 @@ public class DataHibernatorWorkerTest {
         HibernateHelper helper = Mockito.mock(HibernateHelper.class);
         LinkedBlockingQueue queue = Mockito.mock(LinkedBlockingQueue.class);
         Mockito.when(queue.isEmpty()).thenReturn(true);
-        Session session = Mockito.mock(Session.class);
 
         // start workers
-        DataHibernatorWorker.startHibernators(reader, helper, queue, session);
+        DataHibernatorWorker.startHibernators(reader, helper, queue);
 
         ArrayList<DataHibernatorWorker> workers = (ArrayList<DataHibernatorWorker>) workersField.get(null);
         Assertions.assertEquals(expectedSize, workers.size());


### PR DESCRIPTION
## Summary
- Create sessions for `DataHibernatorWorker` via `SessionManager` and close them after processing
- Remove session creation from `FullDownloadWorker.addDownloadRequest`
- Document and centralise long-lived session management in `UNISoNController` and `SessionManager`

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a24f2804c08327ae656c94b4c1ed62

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/357)
<!-- Reviewable:end -->
