### PR TITLE
Ensure full downloads complete before returning

### DIFF
--- a/src/main/java/uk/co/sleonard/unison/UNISoNController.java
+++ b/src/main/java/uk/co/sleonard/unison/UNISoNController.java
@@ -323,6 +323,7 @@ public class UNISoNController {
                         fromDate1,
                         toDate1);
                 headerDownloader2.awaitCompletion();
+                FullDownloadWorker.awaitCompletion();
                 log.debug("Completed header download for {}", group.getName());
             } catch (final IOException e) {
                 e.printStackTrace();

--- a/src/main/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewer.java
+++ b/src/main/java/uk/co/sleonard/unison/gui/generated/MessageStoreViewer.java
@@ -441,9 +441,12 @@ class MessageStoreViewer extends javax.swing.JPanel implements DataChangeListene
                             instance.getNntpReader(), instance.getHelper(), instance);
                 }
             }
+            FullDownloadWorker.awaitCompletion();
         } catch (final UNISoNException e) {
             final String message = "Failed to download extra fields: " + e.getMessage();
             this.showAlert(message);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }// GEN-LAST:event_headersButtonActionPerformed
 

--- a/src/main/java/uk/co/sleonard/unison/input/FullDownloadWorker.java
+++ b/src/main/java/uk/co/sleonard/unison/input/FullDownloadWorker.java
@@ -98,6 +98,18 @@ public class FullDownloadWorker extends SwingWorker {
     }
 
     /**
+     * Blocks until all queued downloads have completed and all worker threads have finished.
+     *
+     * @throws InterruptedException if interrupted while waiting
+     */
+    public static void awaitCompletion() throws InterruptedException {
+        while (!FullDownloadWorker.downloadQueue.isEmpty()
+                || !FullDownloadWorker.downloaders.isEmpty()) {
+            Thread.sleep(500);
+        }
+    }
+
+    /**
      * Start downloaders.
      *
      * @param numberOfDownloaders the number of downloaders

--- a/src/test/java/uk/co/sleonard/unison/input/UNISoNCLI.java
+++ b/src/test/java/uk/co/sleonard/unison/input/UNISoNCLI.java
@@ -104,7 +104,13 @@ public class UNISoNCLI {
     private void downloadAll(final String searchString, final String host) throws UNISoNException {
         final Set<NewsGroup> listNewsgroups = this.controller.listNewsgroups(searchString, host,
                 this.controller.getNntpReader().getClient());
-        this.controller.quickDownload(listNewsgroups, null, null, DownloadMode.ALL);
+        try {
+            this.controller.quickDownload(listNewsgroups, null, null, DownloadMode.ALL);
+            FullDownloadWorker.awaitCompletion();
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new UNISoNException("Download interrupted", e);
+        }
     }
 
     /**
@@ -173,8 +179,11 @@ public class UNISoNCLI {
 
         try {
             this.controller.quickDownload(listNewsgroups, fromDate, toDate, DownloadMode.BASIC);
+            FullDownloadWorker.awaitCompletion();
         } catch (final UNISoNException e) {
             log.error("Error downloading messages", e);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
         DatabaseManagerSwing.main(HibernateHelper.GUI_ARGS);
 


### PR DESCRIPTION
## Summary
- add `FullDownloadWorker.awaitCompletion` to block until queued downloads and worker threads finish
- wait for full downloads to finish in `UNISoNController.quickDownload`
- update GUI and CLI flows to use the blocking call

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a24f22b76c83278b2b88b373a4f313

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/358)
<!-- Reviewable:end -->
