### PR TITLE
test: wait for storeArticleInfo using latch

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build with Maven
         run: mvn -B package --file pom.xml
       - name: Archive distribution
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unison-jar
           path: target/unison-jar-with-dependencies.jar

--- a/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
@@ -258,6 +258,7 @@ class HeaderDownloadWorkerTest {
         final HeaderDownloadWorker spyWorker = Mockito.spy(
                 new HeaderDownloadWorker(new LinkedBlockingQueue<>(),
                         Mockito.mock(Downloader.class)));
+        // Latch ensures storeArticleInfo runs before verification
         final CountDownLatch latch = new CountDownLatch(1);
         Mockito.doAnswer(invocation -> {
             latch.countDown();
@@ -271,6 +272,9 @@ class HeaderDownloadWorkerTest {
             Assertions.assertTrue(latch.await(1, TimeUnit.SECONDS),
                     "storeArticleInfo was not called");
             Mockito.verify(spyWorker).storeArticleInfo(Mockito.any(LinkedBlockingQueue.class));
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Assertions.fail("Interrupted while waiting for storeArticleInfo", e);
         } finally {
             spyWorker.fullstop();
         }

--- a/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
@@ -262,14 +262,18 @@ class HeaderDownloadWorkerTest {
         Mockito.doAnswer(invocation -> {
             latch.countDown();
             return true;
-        }).when(spyWorker).storeArticleInfo(Mockito.any());
+        }).when(spyWorker).storeArticleInfo(Mockito.any(LinkedBlockingQueue.class));
 
         spyWorker.initialise();
         spyWorker.resume();
 
-        Assertions.assertTrue(latch.await(1, TimeUnit.SECONDS));
-        Mockito.verify(spyWorker).storeArticleInfo(Mockito.any());
-        spyWorker.fullstop();
+        try {
+            Assertions.assertTrue(latch.await(1, TimeUnit.SECONDS),
+                    "storeArticleInfo was not called");
+            Mockito.verify(spyWorker).storeArticleInfo(Mockito.any(LinkedBlockingQueue.class));
+        } finally {
+            spyWorker.fullstop();
+        }
     }
 
     @Test

--- a/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/HeaderDownloadWorkerTest.java
@@ -24,7 +24,9 @@ import java.io.StringReader;
 import java.lang.reflect.Field;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -256,12 +258,17 @@ class HeaderDownloadWorkerTest {
         final HeaderDownloadWorker spyWorker = Mockito.spy(
                 new HeaderDownloadWorker(new LinkedBlockingQueue<>(),
                         Mockito.mock(Downloader.class)));
-        Mockito.doReturn(true).when(spyWorker).storeArticleInfo(Mockito.any());
+        final CountDownLatch latch = new CountDownLatch(1);
+        Mockito.doAnswer(invocation -> {
+            latch.countDown();
+            return true;
+        }).when(spyWorker).storeArticleInfo(Mockito.any());
 
         spyWorker.initialise();
         spyWorker.resume();
 
-        Mockito.verify(spyWorker, Mockito.timeout(1000)).storeArticleInfo(Mockito.any());
+        Assertions.assertTrue(latch.await(1, TimeUnit.SECONDS));
+        Mockito.verify(spyWorker).storeArticleInfo(Mockito.any());
         spyWorker.fullstop();
     }
 


### PR DESCRIPTION
## Summary
- Ensure HeaderDownloadWorkerTest uses CountDownLatch to wait for storeArticleInfo
- Verify storeArticleInfo call after awaiting the latch

## Testing
- `mvn -q test` *(fails: Could not resolve org.jacoco:jacoco-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a42e26daf88327aa54185b2b17f405

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/359)
<!-- Reviewable:end -->
