### PR TITLE
test: mock static call in DataHibernatorPoolImplTest

### DIFF
--- a/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
@@ -17,7 +17,8 @@ class DataHibernatorPoolImplTest {
         DataHibernatorPool pool = new DataHibernatorPoolImpl();
         try (MockedStatic<DataHibernatorWorker> mock = Mockito.mockStatic(DataHibernatorWorker.class)) {
             pool.stopAllDownloads();
-            mock.verify(DataHibernatorWorker::stopDownload, Mockito.times(1));
+            mock.verify(DataHibernatorWorker::stopDownload);
+            mock.verifyNoMoreInteractions();
         }
     }
 }

--- a/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
@@ -14,10 +14,10 @@ class DataHibernatorPoolImplTest {
      */
     @Test
     void testStopAllDownloadsDelegates() {
+        DataHibernatorPool pool = new DataHibernatorPoolImpl();
         try (MockedStatic<DataHibernatorWorker> mock = Mockito.mockStatic(DataHibernatorWorker.class)) {
-            DataHibernatorPool pool = new DataHibernatorPoolImpl();
             pool.stopAllDownloads();
-            mock.verify(DataHibernatorWorker::stopDownload);
+            mock.verify(DataHibernatorWorker::stopDownload, Mockito.times(1));
         }
     }
 }

--- a/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
+++ b/src/test/java/uk/co/sleonard/unison/input/DataHibernatorPoolImplTest.java
@@ -1,6 +1,7 @@
 package uk.co.sleonard.unison.input;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 /**
@@ -13,11 +14,10 @@ class DataHibernatorPoolImplTest {
      */
     @Test
     void testStopAllDownloadsDelegates() {
-        DataHibernatorWorker mocked = Mockito.mock(DataHibernatorWorker.class);
+        try (MockedStatic<DataHibernatorWorker> mock = Mockito.mockStatic(DataHibernatorWorker.class)) {
             DataHibernatorPool pool = new DataHibernatorPoolImpl();
             pool.stopAllDownloads();
-
-        Mockito.verify(mocked, Mockito.atLeastOnce()).stopDownload();
-
+            mock.verify(DataHibernatorWorker::stopDownload);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- mock DataHibernatorWorker.stopDownload in DataHibernatorPoolImplTest using Mockito.mockStatic and verify delegation

## Testing
- `mvn -q -Dtest=DataHibernatorPoolImplTest test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.11 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a42e22888883279963cf09409db8e9

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/360)
<!-- Reviewable:end -->
