### PR TITLE
Remove duplicate junit-jupiter dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -312,13 +312,6 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${junit.jupiter.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>


### PR DESCRIPTION
## Summary
- remove duplicate `junit-jupiter` dependency from `pom.xml`

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.11 ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a42e1bec088327bf34083ace4112b6