### PR TITLE
Remove duplicate Jacoco version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
         <swing-layout.version>1.0.3</swing-layout.version>
         <h2.version>2.2.224</h2.version>
         <it.includes></it.includes>
-        <jacoco.version>0.8.11</jacoco.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
## Summary
- Remove redundant `jacoco.version` property in `pom.xml` to ensure a single Jacoco version definition.

## Testing
- `mvn -q test` *(fails: org.jacoco:jacoco-maven-plugin could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a42e20634c8327a3324677aba421b0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/362)
<!-- Reviewable:end -->
