### PR TITLE
Use consistent JAXB namespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>4.0.5</version>
+                <version>2.3.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary
- Align JAXB dependencies to `javax` namespace by using `jaxb-runtime` 2.3.1 alongside `jaxb-api` 2.3.1.

## Testing
- `mvn -q test` *(fails: Plugin org.jacoco:jacoco-maven-plugin:0.8.11 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a42e1a35b483278776205b2b80bb50

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leonarduk/unison/363)
<!-- Reviewable:end -->
